### PR TITLE
Include release tag in vabot slack notification

### DIFF
--- a/oauth-proxy/cicd/buildspec-release.yml
+++ b/oauth-proxy/cicd/buildspec-release.yml
@@ -53,7 +53,7 @@ phases:
       - new_tag=$(increment.sh ${old_tag})
       - echo "creating ${new_tag} release"
       # create release
-      - gh release create ${new_tag}
+      - gh release create ${new_tag} -t ${new_tag}
       - echo tag image
       # tag ecr image with release
       - make tag IMAGE=${IMAGE} TAG=${COMMIT_HASH:0:7} NEW_TAG=${new_tag#*/}


### PR DESCRIPTION
Related story: https://vajira.max.gov/browse/API-6997