### PR TITLE
API-7395 Update Regression Tests to use latest OAuth bot

### DIFF
--- a/oauth-proxy/tests/bats/regression_tests.sh
+++ b/oauth-proxy/tests/bats/regression_tests.sh
@@ -120,7 +120,7 @@ assign_code() {
   local code
   code=$(docker run \
       $network --rm \
-      vasdvp/lighthouse-auth-utils:1.1.2 auth \
+      vasdvp/lighthouse-auth-utils:latest auth \
       --redirect-uri="$REDIRECT_URI" \
       --authorization-url="$HOST" \
       --user-email="$USER_EMAIL" \
@@ -148,7 +148,7 @@ assign_code() {
 # ----
 
 # Pulling latest lighthouse-auth-utils docker image if necessary
-docker pull vasdvp/lighthouse-auth-utils:1.1.2
+docker pull vasdvp/lighthouse-auth-utils:latest
 
 # Start Tests
 


### PR DESCRIPTION
https://vajira.max.gov/browse/API-7395

Following the improvements to the lighthouse-auth-utils repo to prevent race conditions, this PR updates the regression tests to utilize the latest image rather than the specific 1.1.2 version.

https://github.com/department-of-veterans-affairs/lighthouse-auth-utils/pull/19
