### PR TITLE
API-7095 - Publish test image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build/oauth:
 .PHONY: build/oauth_tests
 build/oauth_tests : IMAGE = oauth-proxy-tests
 build/oauth_tests:
-	DIR = $(patsubst %-tests,%,$(IMAGE))
+	DIR := $(patsubst %-tests,%,$(IMAGE))
 	## build:	Build Docker image
 	docker build -t $(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG) \
 		-f $(DIR)/Dockerfile.bats \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ BUILD_VERSION ?= $(shell git rev-parse --short HEAD)
 BUILD_NUMBER ?= $(shell echo $$RANDOM)
 TARGET ?= base
 
-
 # https://stackoverflow.com/questions/10858261/abort-makefile-if-variable-not-set
 # Fuction to check if variables are defined
 check_defined = \
@@ -56,13 +55,13 @@ build/oauth:
 		--build-arg BUILD_NUMBER=$(BUILD_NUMBER) \
 		--no-cache .
 
-## build/saml:	Build saml-proxy image
-.PHONY: build/saml
-build/saml : IMAGE = saml-proxy
-build/saml:
+## build/oauth_tests:	Build oauth-proxy-tests image
+.PHONY: build/oauth_tests
+build/oauth_tests : IMAGE = oauth-proxy-tests
+build/oauth_tests:
 	## build:	Build Docker image
 	docker build -t $(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG) \
-		-f $(IMAGE)/DockerfileFG \
+		-f $(patsubst %-tests,%,$(IMAGE))/Dockerfile.bats \
 		--build-arg AWS_ACCOUNT_ID=$(AWS_ACCOUNT_ID) \
 		--build-arg BUILD_DATE_TIME=$(BUILD_DATE_TIME) \
 		--build-arg BUILD_TOOL=$(BUILD_TOOL) \
@@ -73,7 +72,7 @@ build/saml:
 ## lint: Linting
 .PHONY: lint
 lint:
-	@:$(call check_defined, IMAGE, IMAGE variable should be saml-proxy or oauth-proxy)
+	@:$(call check_defined, IMAGE, IMAGE variable should be oauth-proxy)
 	docker run --rm --entrypoint='' \
 		-w "/home/node" \
 		$(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG) \
@@ -82,7 +81,7 @@ lint:
 ## test: Unit Tests
 .PHONY: test
 test:
-	@:$(call check_defined, IMAGE, IMAGE variable should be saml-proxy or oauth-proxy)
+	@:$(call check_defined, IMAGE, IMAGE variable should be oauth-proxy)
 	docker run --rm --entrypoint='' \
 		-w "/home/node" \
 		$(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG) \
@@ -91,31 +90,31 @@ test:
 ## pull: 	Pull an image to ECR
 .PHONY: pull
 pull:
-	@:$(call check_defined, IMAGE, IMAGE variable should be saml-proxy or oauth-proxy)
+	@:$(call check_defined, IMAGE, IMAGE variable should be oauth-proxy or oauth-proxy-tests)
 	docker pull $(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG)
 
 ## push: 	Pushes an image to ECR
 .PHONY: push
 push:
-	@:$(call check_defined, IMAGE, IMAGE variable should be saml-proxy or oauth-proxy)
+	@:$(call check_defined, IMAGE, IMAGE variable should be oauth-proxy or oauth-proxy-tests)
 	docker push $(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG)
 
 ## tag:	Adds a tag to an existing image in ECR
 .PHONY: tag
 tag:
-	@:$(call check_defined, IMAGE, IMAGE variable should be saml-proxy or oauth-proxy)
+	@:$(call check_defined, IMAGE, IMAGE variable should be oauth-proxy or oauth-proxy-tests)
 	@echo Tagging $(NAMESPACE)/$(IMAGE):$(TAG) with $(NEW_TAG)
 	@aws ecr put-image --repository-name $(NAMESPACE)/$(IMAGE) --image-tag $(NEW_TAG) --image-manifest "$$(aws ecr batch-get-image --repository-name $(NAMESPACE)/$(IMAGE) --image-ids imageTag=$(TAG) --query 'images[].imageManifest' --output text)" > /dev/null
 
 ## labels: Get ECR labels.
 .PHONY: get_labels
 get_labels:
-	@:$(call check_defined, IMAGE, IMAGE variable should be saml-proxy or oauth-proxy)
+	@:$(call check_defined, IMAGE, IMAGE variable should be oauth-proxy or oauth-proxy-tests)
 	@echo Getting labels from ECR  for $(NAMESPACE)/$(IMAGE):$(TAG)
 	@aws ecr batch-get-image --repository-name $(NAMESPACE)/$(IMAGE) --image-id imageTag=$(TAG) --accepted-media-types "application/vnd.docker.distribution.manifest.v1+json" --output json |jq -r '.images[].imageManifest' |jq -r '.history[0].v1Compatibility' |jq -r '.config.Labels'
 
 ## clean:	Removes a local image
 .PHONY: clean
 clean:
-	@:$(call check_defined, IMAGE, IMAGE variable should be saml-proxy or oauth-proxy)
+	@:$(call check_defined, IMAGE, IMAGE variable should be oauth-proxy or oauth-proxy-tests)
 	docker image rm $(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG)

--- a/Makefile
+++ b/Makefile
@@ -59,16 +59,15 @@ build/oauth:
 .PHONY: build/oauth_tests
 build/oauth_tests : IMAGE = oauth-proxy-tests
 build/oauth_tests:
-	DIR := $(patsubst %-tests,%,$(IMAGE))
 	## build:	Build Docker image
 	docker build -t $(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG) \
-		-f $(DIR)/Dockerfile.bats \
+		-f $(patsubst %-tests,%,$(IMAGE))/Dockerfile.bats \
 		--build-arg AWS_ACCOUNT_ID=$(AWS_ACCOUNT_ID) \
 		--build-arg BUILD_DATE_TIME=$(BUILD_DATE_TIME) \
 		--build-arg BUILD_TOOL=$(BUILD_TOOL) \
 		--build-arg VERSION=$(BUILD_VERSION) \
 		--build-arg BUILD_NUMBER=$(BUILD_NUMBER) \
-		--no-cache $(DIR)
+		--no-cache $(patsubst %-tests,%,$(IMAGE))
 
 ## lint: Linting
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ build/oauth_tests:
 		--build-arg AWS_ACCOUNT_ID=$(AWS_ACCOUNT_ID) \
 		--build-arg BUILD_DATE_TIME=$(BUILD_DATE_TIME) \
 		--build-arg BUILD_TOOL=$(BUILD_TOOL) \
-		--build-arg VERSION=$(BUILD_VERSION) \
+		--build-arg BUILD_VERSION=$(BUILD_VERSION) \
 		--build-arg BUILD_NUMBER=$(BUILD_NUMBER) \
 		--no-cache $(patsubst %-tests,%,$(IMAGE))
 

--- a/Makefile
+++ b/Makefile
@@ -59,15 +59,16 @@ build/oauth:
 .PHONY: build/oauth_tests
 build/oauth_tests : IMAGE = oauth-proxy-tests
 build/oauth_tests:
+	DIR = $(patsubst %-tests,%,$(IMAGE))
 	## build:	Build Docker image
 	docker build -t $(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG) \
-		-f $(patsubst %-tests,%,$(IMAGE))/Dockerfile.bats \
+		-f $(DIR)/Dockerfile.bats \
 		--build-arg AWS_ACCOUNT_ID=$(AWS_ACCOUNT_ID) \
 		--build-arg BUILD_DATE_TIME=$(BUILD_DATE_TIME) \
 		--build-arg BUILD_TOOL=$(BUILD_TOOL) \
 		--build-arg VERSION=$(BUILD_VERSION) \
 		--build-arg BUILD_NUMBER=$(BUILD_NUMBER) \
-		--no-cache .
+		--no-cache $(DIR)
 
 ## lint: Linting
 .PHONY: lint

--- a/oauth-proxy/Dockerfile.bats
+++ b/oauth-proxy/Dockerfile.bats
@@ -1,7 +1,30 @@
 FROM vasdvp/health-apis-centos:8
 
-COPY /tests/bats /bats
-COPY /entrypoint_test.sh /bats/entrypoint_test.sh
+# Build Args
+ARG BUILD_DATE_TIME
+ARG VERSION
+ARG BUILD_NUMBER
+ARG BUILD_TOOL
+
+# Static Labels
+LABEL org.opencontainers.image.authors="leeroy-jenkles@va.gov" \
+      org.opencontainers.image.url="https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy/tree/master/oauth-proxy/Dockerfile.bats" \
+      org.opencontainers.image.documentation="https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy/tree/master/lighthouse-oauth-proxy/README.md" \
+      org.opencontainers.image.vendor="lighthouse" \
+      org.opencontainers.image.title="oauth-proxy-tests" \
+      org.opencontainers.image.source="https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy/tree/master/oauth-proxy" \
+      org.opencontainers.image.description="Oauth Proxy Tests for Lighthouse APIs"
+
+# Dynamic Labels
+LABEL org.opencontainers.image.created=${BUILD_DATE_TIME} \
+      org.opencontainers.image.version=${VERSION} \
+      gov.va.build.number=${BUILD_NUMBER} \
+      gov.va.build.tool=${BUILD_TOOL}
+
+WORKDIR /bats
+
+COPY ./tests/bats ./
+COPY ./entrypoint_test.sh ./entrypoint_test.sh
 
 RUN dnf update -y && \
     dnf install git -y
@@ -9,12 +32,11 @@ RUN dnf update -y && \
 RUN dnf install -y -q https://download.docker.com/linux/centos/8/x86_64/stable/Packages/containerd.io-1.4.4-3.1.el8.x86_64.rpm && \
     curl -fskLS https://get.docker.com | sh
 
-RUN git clone https://github.com/bats-core/bats-core 
+RUN git clone https://github.com/bats-core/bats-core
 
 WORKDIR bats-core
 
-RUN ./install.sh /usr/local 
-
+RUN ./install.sh /usr/local
 
 WORKDIR /bats
 

--- a/oauth-proxy/Dockerfile.bats
+++ b/oauth-proxy/Dockerfile.bats
@@ -2,7 +2,7 @@ FROM vasdvp/health-apis-centos:8
 
 # Build Args
 ARG BUILD_DATE_TIME
-ARG VERSION
+ARG BUILD_VERSION
 ARG BUILD_NUMBER
 ARG BUILD_TOOL
 
@@ -17,7 +17,7 @@ LABEL org.opencontainers.image.authors="leeroy-jenkles@va.gov" \
 
 # Dynamic Labels
 LABEL org.opencontainers.image.created=${BUILD_DATE_TIME} \
-      org.opencontainers.image.version=${VERSION} \
+      org.opencontainers.image.version=${BUILD_VERSION} \
       gov.va.build.number=${BUILD_NUMBER} \
       gov.va.build.tool=${BUILD_TOOL}
 

--- a/oauth-proxy/Dockerfile.bats.dockerignore
+++ b/oauth-proxy/Dockerfile.bats.dockerignore
@@ -1,0 +1,3 @@
+*/**
+!tests/bats
+!entrypoint_test.sh

--- a/oauth-proxy/DockerfileFG
+++ b/oauth-proxy/DockerfileFG
@@ -9,7 +9,7 @@ ARG BUILD_TOOL
 # Static Labels
 LABEL org.opencontainers.image.authors="leeroy-jenkles@va.gov" \
       org.opencontainers.image.url="https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy/tree/master/oauth-proxy/DockerfileFG" \
-      org.opencontainers.image.documentation="https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy/tree/master/oauth-proxy/README.md" \
+      org.opencontainers.image.documentation="https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy/tree/master/lighthouse-oauth-proxy/README.md" \
       org.opencontainers.image.vendor="lighthouse" \
       org.opencontainers.image.title="oauth-proxy" \
       org.opencontainers.image.source="https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy/tree/master/oauth-proxy" \

--- a/oauth-proxy/README.md
+++ b/oauth-proxy/README.md
@@ -8,7 +8,7 @@ This is a slim proxy for transforming and storing values from Okta's OpenID Conn
 
 ## Usage
 
-- Run `npm i` to install dependencies
+- Run `npm i` to install dependencies.
 
 ### Quick Start Docker Compose
 

--- a/oauth-proxy/cicd/buildspec-ci.yml
+++ b/oauth-proxy/cicd/buildspec-ci.yml
@@ -62,6 +62,15 @@ phases:
       - make lint IMAGE=${IMAGE} TAG=${COMMIT_HASH}
       # run unit tests
       - make test IMAGE=${IMAGE} TAG=${COMMIT_HASH}
+      # Build the tests image
+      - echo Building tests image
+      - make build/oauth_tests  \
+         TAG=${COMMIT_HASH} \
+         IMAGE=${IMAGE}-tests \
+         VERSION=${COMMIT_HASH} \
+         TARGET=deploy \
+         BUILD_TOOL=CodeBuild \
+         BUILD_NUMBER=${CODEBUILD_BUILD_ID}
       # Login to ECR prior to push
       - echo Logging into ECR
       - make login

--- a/oauth-proxy/cicd/buildspec-ci.yml
+++ b/oauth-proxy/cicd/buildspec-ci.yml
@@ -67,7 +67,7 @@ phases:
       - make build/oauth_tests  \
          TAG=${COMMIT_HASH} \
          IMAGE=${IMAGE}-tests \
-         VERSION=${COMMIT_HASH} \
+         BUILD_VERSION=${COMMIT_HASH} \
          BUILD_TOOL=CodeBuild \
          BUILD_NUMBER=${CODEBUILD_BUILD_ID}
       # Login to ECR prior to push

--- a/oauth-proxy/cicd/buildspec-ci.yml
+++ b/oauth-proxy/cicd/buildspec-ci.yml
@@ -68,7 +68,6 @@ phases:
          TAG=${COMMIT_HASH} \
          IMAGE=${IMAGE}-tests \
          VERSION=${COMMIT_HASH} \
-         TARGET=deploy \
          BUILD_TOOL=CodeBuild \
          BUILD_NUMBER=${CODEBUILD_BUILD_ID}
       # Login to ECR prior to push

--- a/oauth-proxy/cicd/buildspec-ci.yml
+++ b/oauth-proxy/cicd/buildspec-ci.yml
@@ -77,3 +77,4 @@ phases:
       - echo Pushing image to ECR
       - time="${time}\nPush - $(date +%r) - started"
       - make push IMAGE=${IMAGE} TAG=${COMMIT_HASH}
+      - make push IMAGE=${IMAGE}-tests TAG=${COMMIT_HASH}

--- a/oauth-proxy/tests/bats/regression_tests.sh
+++ b/oauth-proxy/tests/bats/regression_tests.sh
@@ -120,7 +120,7 @@ assign_code() {
   local code
   code=$(docker run \
       $network --rm \
-      vasdvp/lighthouse-auth-utils:1.1.2 auth \
+      vasdvp/lighthouse-auth-utils:latest auth \
       --redirect-uri="$REDIRECT_URI" \
       --authorization-url="$HOST" \
       --user-email="$USER_EMAIL" \
@@ -148,7 +148,7 @@ assign_code() {
 # ----
 
 # Pulling latest lighthouse-auth-utils docker image if necessary
-docker pull vasdvp/lighthouse-auth-utils:1.1.2
+docker pull vasdvp/lighthouse-auth-utils:latest
 
 # Start Tests
 


### PR DESCRIPTION
https://vajira.max.gov/browse/API-7095

Build and publish an `oauth-proxy-tests` image as part of CICD. This image will be hooked into the deploy process in a future story, allowing for fully automated regression tests.