### PR TITLE
Added release tag to oauth-proxy-tests image as well

### DIFF
--- a/oauth-proxy/cicd/buildspec-release.yml
+++ b/oauth-proxy/cicd/buildspec-release.yml
@@ -25,7 +25,7 @@ env:
     REPO: "lighthouse-oauth-proxy"
     IMAGE: "oauth-proxy"
     # Checks that are not included for the ghstatus script.
-    XCHECKS: "oauth-proxy-release,oauth-proxy-tests-release"
+    XCHECKS: "oauth-proxy-release"
   parameter-store:
     GITHUB_TOKEN: "/dvp/devops/va_bot_github_token"
     # SLACK_WEBHOOK should be a webhook that posts to the Slack channel you want notifications to go to

--- a/oauth-proxy/cicd/buildspec-release.yml
+++ b/oauth-proxy/cicd/buildspec-release.yml
@@ -25,7 +25,7 @@ env:
     REPO: "lighthouse-oauth-proxy"
     IMAGE: "oauth-proxy"
     # Checks that are not included for the ghstatus script.
-    XCHECKS: "oauth-proxy-release,saml-proxy"
+    XCHECKS: "oauth-proxy-release,oauth-proxy-tests-release"
   parameter-store:
     GITHUB_TOKEN: "/dvp/devops/va_bot_github_token"
     # SLACK_WEBHOOK should be a webhook that posts to the Slack channel you want notifications to go to
@@ -55,8 +55,9 @@ phases:
       # create release
       - gh release create ${new_tag} -t ${new_tag}
       - echo tag image
-      # tag ecr image with release
+      # tag ecr images with release
       - make tag IMAGE=${IMAGE} TAG=${COMMIT_HASH:0:7} NEW_TAG=${new_tag#*/}
+      - make tag IMAGE=${IMAGE}-tests TAG=${COMMIT_HASH:0:7} NEW_TAG=${new_tag#*/}
       - |
         if [[ ${DEPLOY} == "true" ]]; then
           echo "initiating deploy for ${new_tag}"


### PR DESCRIPTION
Small follow-up to https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy/pull/12

This adds the release tag to the oauth-proxy-tests image as well for ease of use.