### PR TITLE
API-7002 - Prep for shorter refresh tokens

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -62,6 +62,10 @@ function processArgs() {
           "hmac secret to hash access tokens being stored in client credentials table.",
         required: true,
       },
+      refresh_token_ttl: {
+        description: "TTL (days) of a refresh token",
+        required: true,
+      },
       okta_url: {
         description: "base URL of okta organization",
         required: true,

--- a/dev-config.base.json
+++ b/dev-config.base.json
@@ -7,6 +7,7 @@
   "dynamo_launch_context_table": "launch-context-table",
   "dynamo_static_token_table": "static-token-table",
   "hmac_secret": "hmac-secret",
+  "refresh_token_ttl": 42,
   "okta_url": "https://example.okta.com",
   "validate_post_endpoint": "https://example.com/validation",
   "validate_apiKey": "validate-api-key",

--- a/metrics.js
+++ b/metrics.js
@@ -48,6 +48,7 @@ const refreshTokenLifeCycleHistogram = new client.Histogram({
   name: "refresh_token_life_cycle_histogram",
   help:
     "measures the time in days between a refresh token's instantiation and its use.",
+  labelNames: ["client_id"],
   buckets: [1, 3, 5, 10, 21, 42],
 });
 

--- a/oauthHandlers/authorizeHandler.js
+++ b/oauthHandlers/authorizeHandler.js
@@ -2,6 +2,7 @@
 const { URLSearchParams, URL } = require("url");
 const { loginBegin } = require("../metrics");
 const { v4: uuidv4 } = require("uuid");
+const { addMinutes, getUnixTime } = require("date-fns");
 
 /**
  * Checks for valid authorization request and proxies to authorization server.
@@ -75,7 +76,8 @@ const authorizeHandler = async (
       internal_state: internal_state,
       state: state,
       redirect_uri: client_redirect,
-      expires_on: Math.round(Date.now() / 1000) + 60 * 10, // 10 minutes
+      expires_on: getUnixTime(addMinutes(Date.now(), 10)),
+      client_id: client_id,
     };
 
     // If the launch scope is included then also

--- a/oauthHandlers/tokenHandlerStrategyClasses/documentStrategies/getDocumentByRefreshTokenStrategy.js
+++ b/oauthHandlers/tokenHandlerStrategyClasses/documentStrategies/getDocumentByRefreshTokenStrategy.js
@@ -1,12 +1,11 @@
 const { hashString } = require("../../../utils");
 
 class GetDocumentByRefreshTokenStrategy {
-  constructor(req, logger, dynamoClient, config, client_id) {
+  constructor(req, logger, dynamoClient, config) {
     this.req = req;
     this.logger = logger;
     this.dynamoClient = dynamoClient;
     this.config = config;
-    this.client_id = client_id;
   }
 
   /**

--- a/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClientBuilder.js
+++ b/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClientBuilder.js
@@ -92,12 +92,12 @@ const getStrategies = (
 ) => {
   let strategies;
   if (req.body.grant_type === "refresh_token") {
-    const temp_client_id = req.body.client_id;
+    const clientMetadata = createClientMetadata(redirect_uri, req, config);
     strategies = {
       getTokenStrategy: new RefreshTokenStrategy(
         req,
         logger,
-        new issuer.Client(createClientMetadata(redirect_uri, req, config)),
+        new issuer.Client(clientMetadata),
         dynamoClient,
         config,
         staticTokens
@@ -106,8 +106,7 @@ const getStrategies = (
         req,
         logger,
         dynamoClient,
-        config,
-        temp_client_id
+        config
       ),
       saveDocumentToDynamoStrategy: new SaveDocumentStateStrategy(
         req,
@@ -115,7 +114,8 @@ const getStrategies = (
         dynamoClient,
         config,
         issuer.issuer,
-        refreshTokenLifeCycleHistogram
+        refreshTokenLifeCycleHistogram,
+        clientMetadata.client_id
       ),
       getPatientInfoStrategy: new GetPatientInfoFromValidateEndpointStrategy(
         validateToken,
@@ -126,12 +126,13 @@ const getStrategies = (
       dbMissCounter: missRefreshTokenCounter,
     };
   } else if (req.body.grant_type === "authorization_code") {
+    const clientMetadata = createClientMetadata(redirect_uri, req, config);
     strategies = {
       getTokenStrategy: new AuthorizationCodeStrategy(
         req,
         logger,
         redirect_uri,
-        new issuer.Client(createClientMetadata(redirect_uri, req, config))
+        new issuer.Client(clientMetadata)
       ),
       getDocumentFromDynamoStrategy: new GetDocumentByCodeStrategy(
         req,
@@ -145,7 +146,8 @@ const getStrategies = (
         dynamoClient,
         config,
         issuer.issuer,
-        refreshTokenLifeCycleHistogram
+        refreshTokenLifeCycleHistogram,
+        clientMetadata.client_id
       ),
       getPatientInfoStrategy: new GetPatientInfoFromValidateEndpointStrategy(
         validateToken,

--- a/package-lock.json
+++ b/package-lock.json
@@ -921,7 +921,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2572,7 +2571,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3320,8 +3318,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -5855,7 +5852,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -321,6 +321,7 @@ const createFakeConfig = () => {
     dynamo_oauth_requests_table: "OAuthRequestsV2",
     dynamo_launch_context_table: "LaunchContext",
     hmac_secret: "secret",
+    refresh_token_ttl: 42,
     okta_url: "https://deptva-eval.okta.com",
     validate_post_endpoint:
       "https://sandbox-api.va.gov/internal/auth/v1/validation",

--- a/utils.js
+++ b/utils.js
@@ -75,8 +75,7 @@ function parseClientId(clientId) {
 
 const hashString = (unhashedString, secret) => {
   const hmac = crypto.createHmac("sha256", secret);
-  let hashedString = hmac.update(unhashedString).digest("hex");
-  return hashedString;
+  return hmac.update(unhashedString).digest("hex");
 };
 
 const isString = (obj) => typeof obj === "string" || obj instanceof String;


### PR DESCRIPTION
https://vajira.max.gov/browse/API-7002

Prep work for reducing refresh token TTL.

This adds two new fields to the db:
- issued_on
  - written for new records during authorization code grant
  - back-filled for existing records during refresh token grant
- client_id
  - written for new records during authorization code grant
  - back-filled for existing records during refresh token grant

These allow the metrics to work with multiple TTLs (old 42, new TBD) and to single out individual clients.

One new required config:
- refresh_token_ttl (42)

#### Test scenarios
1. Checkout master
2. Obtain a refresh token (A)
    - observe db `expires_on: +42 days`
3. Use refresh token A
    - observe db `expires_on: +42 days`
    - observe metric `refresh_token_life_cycle_histogram_bucket{le="1",app="oauth_proxy"} 1`
4. Checkout this branch
5. Use refresh token A
    - observe db `issued_on: now`
    - observe db `expires_on: +42 days`
    - observe db `client_id: client_id`
    - observe metric `refresh_token_life_cycle_histogram_bucket{le="1",client_id="client_id",app="oauth_proxy"} 2`
6. Obtain a refresh token (B)
    - observe db `issued_on: now`
    - observe db `expires_on: +42 days`
    - observe db `client_id: client_id`
7. Use refresh token B
    - observe db `issued_on: now`
    - observe db `expires_on: +42 days`
    - observe db `client_id: client_id`
    - observe metric `refresh_token_life_cycle_histogram_bucket{le="1",client_id="client_id",app="oauth_proxy"} 3`

#### Related PRs

- https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy-configs/pull/39