### PR TITLE
Api 9130 issued endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The following dev-config value needs to be set `"dynamo_local": "localhost:8000"
 
 ```
 docker run -d -p 8000:8000 amazon/dynamodb-local -jar DynamoDBLocal.jar -sharedDb -inMemory
-node dynamo_schema.js --local=true
+node src/dynamo_schema.js --local=true
 ```
 
 Start the Oauth Proxy

--- a/dev-config.base.json
+++ b/dev-config.base.json
@@ -14,6 +14,7 @@
   "okta_token": "okta-token",
   "enable_pkce_authorization_flow": true,
   "enable_smart_launch_service": true,
+  "enable_issued_service": true,
   "enable_static_token_service": true,
   "enable_claims_service": true,
   "routes": {
@@ -44,6 +45,7 @@
       "jwks": "/keys",
       "grants": "/grants",
       "smart_launch": "/smart/launch",
+      "issued": "/issued",
       "claims": "/claims"
     }
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -111,6 +111,11 @@ function processArgs() {
         required: false,
         default: false,
       },
+      enable_issued_service: {
+        description: "Enable Lighthouse issued lookup service?",
+        required: false,
+        default: false,
+      },
       enable_static_token_service: {
         description: "Enable static token lookup service?",
         required: false,
@@ -268,6 +273,11 @@ function processArgs() {
             description: "The path component for the SMART launch service",
             required: true,
             default: "/smart/launch",
+          },
+          issued: {
+            description: "The path component for the Lighthouse issued service",
+            required: true,
+            default: "/issued",
           },
           claims: {
             description: "The path component for the claims service",

--- a/src/dynamo_schema.js
+++ b/src/dynamo_schema.js
@@ -269,7 +269,9 @@ function createStaticTokenEntry() {
       expires_in: { N: "3600" },
       icn: { S: "555" },
       aud: { S: "http://localhost:7100/services/static-only" },
-      cross_hash: { S: "ada386dcfd6cbd96c0e345d0599503f488f6a7e103b1096e0bd363180204bce5" },
+      cross_hash: {
+        S: "ada386dcfd6cbd96c0e345d0599503f488f6a7e103b1096e0bd363180204bce5",
+      },
     },
   };
 

--- a/src/dynamo_schema.js
+++ b/src/dynamo_schema.js
@@ -196,14 +196,31 @@ dynamo.createTable(tableParams, (err, data) => {
 
 tableParams = {
   AttributeDefinitions: [
+    { AttributeName: "access_token", AttributeType: "S" },
     { AttributeName: "static_refresh_token", AttributeType: "S" },
   ],
-  KeySchema: [{ AttributeName: "static_refresh_token", KeyType: "HASH" }],
+  KeySchema: [{ AttributeName: "access_token", KeyType: "HASH" }],
   ProvisionedThroughput: {
     ReadCapacityUnits: 10,
     WriteCapacityUnits: 10,
   },
   GlobalSecondaryIndexes: [
+    {
+      IndexName: "static_access_token_index",
+      KeySchema: [
+        {
+          AttributeName: "access_token",
+          KeyType: "HASH",
+        },
+      ],
+      Projection: {
+        ProjectionType: "ALL",
+      },
+      ProvisionedThroughput: {
+        ReadCapacityUnits: 10,
+        WriteCapacityUnits: 10,
+      },
+    },
     {
       IndexName: "static_refresh_token_index",
       KeySchema: [
@@ -251,6 +268,7 @@ function createStaticTokenEntry() {
       },
       static_expires_in: { N: "3600" },
       static_icn: { S: "555" },
+      static_aud: { S: "http://localhost:7100/services/static-only" },
     },
   };
 

--- a/src/dynamo_schema.js
+++ b/src/dynamo_schema.js
@@ -269,7 +269,7 @@ function createStaticTokenEntry() {
       expires_in: { N: "3600" },
       icn: { S: "555" },
       aud: { S: "http://localhost:7100/services/static-only" },
-      cross_hash: {
+      check_sum: {
         S: "ada386dcfd6cbd96c0e345d0599503f488f6a7e103b1096e0bd363180204bce5",
       },
     },

--- a/src/dynamo_schema.js
+++ b/src/dynamo_schema.js
@@ -260,7 +260,7 @@ function createStaticTokenEntry() {
   let itemParams = {
     TableName: "StaticTokens",
     Item: {
-      static_access_token: { S: "123456789" },
+      access_token: { S: "123456789" },
       static_refresh_token: { S: "987654321" },
       static_scopes: {
         S:

--- a/src/dynamo_schema.js
+++ b/src/dynamo_schema.js
@@ -269,7 +269,7 @@ function createStaticTokenEntry() {
       expires_in: { N: "3600" },
       icn: { S: "555" },
       aud: { S: "http://localhost:7100/services/static-only" },
-      check_sum: {
+      checksum: {
         S: "ada386dcfd6cbd96c0e345d0599503f488f6a7e103b1096e0bd363180204bce5",
       },
     },

--- a/src/dynamo_schema.js
+++ b/src/dynamo_schema.js
@@ -261,7 +261,9 @@ function createStaticTokenEntry() {
     TableName: "StaticTokens",
     Item: {
       access_token: { S: "123456789" },
-      refresh_token: { S: "987654321" },
+      refresh_token: {
+        S: "6a9cf6b1af1d8205b771d7c7b7e1770e630f763a755b2f86833ee8ce544df25e",
+      },
       scopes: {
         S:
           "openid profile patient/Medication.read launch/patient offline_access",

--- a/src/dynamo_schema.js
+++ b/src/dynamo_schema.js
@@ -197,7 +197,7 @@ dynamo.createTable(tableParams, (err, data) => {
 tableParams = {
   AttributeDefinitions: [
     { AttributeName: "access_token", AttributeType: "S" },
-    { AttributeName: "static_refresh_token", AttributeType: "S" },
+    { AttributeName: "refresh_token", AttributeType: "S" },
   ],
   KeySchema: [{ AttributeName: "access_token", KeyType: "HASH" }],
   ProvisionedThroughput: {
@@ -206,7 +206,7 @@ tableParams = {
   },
   GlobalSecondaryIndexes: [
     {
-      IndexName: "static_access_token_index",
+      IndexName: "access_token_index",
       KeySchema: [
         {
           AttributeName: "access_token",
@@ -222,10 +222,10 @@ tableParams = {
       },
     },
     {
-      IndexName: "static_refresh_token_index",
+      IndexName: "refresh_token_index",
       KeySchema: [
         {
-          AttributeName: "static_refresh_token",
+          AttributeName: "refresh_token",
           KeyType: "HASH",
         },
       ],
@@ -261,14 +261,14 @@ function createStaticTokenEntry() {
     TableName: "StaticTokens",
     Item: {
       access_token: { S: "123456789" },
-      static_refresh_token: { S: "987654321" },
-      static_scopes: {
+      refresh_token: { S: "987654321" },
+      scopes: {
         S:
           "openid profile patient/Medication.read launch/patient offline_access",
       },
-      static_expires_in: { N: "3600" },
-      static_icn: { S: "555" },
-      static_aud: { S: "http://localhost:7100/services/static-only" },
+      expires_in: { N: "3600" },
+      icn: { S: "555" },
+      aud: { S: "http://localhost:7100/services/static-only" },
     },
   };
 

--- a/src/dynamo_schema.js
+++ b/src/dynamo_schema.js
@@ -269,6 +269,7 @@ function createStaticTokenEntry() {
       expires_in: { N: "3600" },
       icn: { S: "555" },
       aud: { S: "http://localhost:7100/services/static-only" },
+      cross_hash: { S: "ada386dcfd6cbd96c0e345d0599503f488f6a7e103b1096e0bd363180204bce5" },
     },
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -200,6 +200,14 @@ function buildApp(
     );
   }
 
+  if (config.enable_issued_service) {
+    router.get(config.routes.app_routes.issued, async (req, res, next) => {
+      await oauthHandlers
+        .issuedRequestHandler(config, logger, dynamoClient, req, res, next)
+        .catch(next);
+    });
+  }
+
   if (config.enable_claims_service) {
     router.post(config.routes.app_routes.claims, async (req, res, next) => {
       await oauthHandlers

--- a/src/oauthHandlers/index.js
+++ b/src/oauthHandlers/index.js
@@ -6,5 +6,6 @@ module.exports = {
   redirectHandler: require("./redirectHandler"),
   revokeUserGrantHandler: require("./revokeUserGrantHandler"),
   launchRequestHandler: require("./launchRequestHandler"),
+  issuedRequestHandler: require("./issuedRequestHandler"),
   claimsHandler: require("./claimsHandler"),
 };

--- a/src/oauthHandlers/issuedRequestHandler.js
+++ b/src/oauthHandlers/issuedRequestHandler.js
@@ -28,7 +28,7 @@ const issuedRequestHandler = async (
     access_token,
     config.dynamo_static_token_table
   );
-  if (documentResponse && documentResponse.static_access_token) {
+  if (documentResponse && documentResponse.access_token) {
     res.json({
       static: true,
       scopes: documentResponse.static_scopes,

--- a/src/oauthHandlers/issuedRequestHandler.js
+++ b/src/oauthHandlers/issuedRequestHandler.js
@@ -32,8 +32,7 @@ const issuedRequestHandler = async (
     let cross_check =
       documentResponse.access_token + "-" + documentResponse.icn;
     if (
-      hashString(cross_check, config.hmac_secret) ==
-      documentResponse.cross_hash
+      hashString(cross_check, config.hmac_secret) == documentResponse.cross_hash
     ) {
       res.json({
         static: true,

--- a/src/oauthHandlers/issuedRequestHandler.js
+++ b/src/oauthHandlers/issuedRequestHandler.js
@@ -29,10 +29,9 @@ const issuedRequestHandler = async (
     config.dynamo_static_token_table
   );
   if (documentResponse && documentResponse.access_token) {
-    let cross_check =
-      documentResponse.access_token + "-" + documentResponse.icn;
+    let check_sum = documentResponse.access_token + "-" + documentResponse.icn;
     if (
-      hashString(cross_check, config.hmac_secret) == documentResponse.cross_hash
+      hashString(check_sum, config.hmac_secret) == documentResponse.check_sum
     ) {
       res.json({
         static: true,

--- a/src/oauthHandlers/issuedRequestHandler.js
+++ b/src/oauthHandlers/issuedRequestHandler.js
@@ -31,10 +31,10 @@ const issuedRequestHandler = async (
   if (documentResponse && documentResponse.access_token) {
     res.json({
       static: true,
-      scopes: documentResponse.static_scopes,
-      expires_in: documentResponse.static_expires_in,
-      icn: documentResponse.static_icn,
-      aud: documentResponse.static_aud,
+      scopes: documentResponse.scopes,
+      expires_in: documentResponse.expires_in,
+      icn: documentResponse.icn,
+      aud: documentResponse.aud,
     });
   } else {
     return res.sendStatus(401);

--- a/src/oauthHandlers/issuedRequestHandler.js
+++ b/src/oauthHandlers/issuedRequestHandler.js
@@ -29,9 +29,11 @@ const issuedRequestHandler = async (
     config.dynamo_static_token_table
   );
   if (documentResponse && documentResponse.access_token) {
-    let check_sum = documentResponse.access_token + "-" + documentResponse.icn;
+    let token_icn_pair =
+      documentResponse.access_token + "-" + documentResponse.icn;
     if (
-      hashString(check_sum, config.hmac_secret) == documentResponse.check_sum
+      hashString(token_icn_pair, config.hmac_secret) ==
+      documentResponse.checksum
     ) {
       res.json({
         static: true,

--- a/src/oauthHandlers/issuedRequestHandler.js
+++ b/src/oauthHandlers/issuedRequestHandler.js
@@ -1,0 +1,46 @@
+const { hashString, parseBearerAuthorization } = require("../utils");
+const {
+  GetDocumentByAccessTokenStrategy,
+} = require("./tokenHandlerStrategyClasses/documentStrategies/getDocumentByAccessTokenStrategy");
+
+/*
+ * Handler for looking up Lighthouse issued tokens by access_token.
+ */
+const issuedRequestHandler = async (
+  config,
+  logger,
+  dynamoClient,
+  req,
+  res,
+  next
+) => {
+  const getDocumentStrategy = new GetDocumentByAccessTokenStrategy(
+    logger,
+    dynamoClient,
+    config,
+    hashString
+  );
+  let access_token = parseBearerAuthorization(req.headers.authorization);
+  if (!access_token) {
+    return res.sendStatus(401);
+  }
+  let documentResponse = await getDocumentStrategy.getDocument(
+    access_token,
+    config.dynamo_static_token_table
+  );
+  if (documentResponse && documentResponse.static_access_token) {
+    res.json({
+      static: true,
+      scopes: documentResponse.static_scopes,
+      expires_in: documentResponse.static_expires_in,
+      icn: documentResponse.static_icn,
+      aud: documentResponse.static_aud,
+    });
+  } else {
+    return res.sendStatus(401);
+  }
+
+  return next();
+};
+
+module.exports = issuedRequestHandler;

--- a/src/oauthHandlers/launchRequestHandler.js
+++ b/src/oauthHandlers/launchRequestHandler.js
@@ -20,10 +20,10 @@ const launchRequestHandler = async (
     hashString
   );
 
-  let hashedToken = hashString(res.locals.jwt, this.config.hmac_secret);
+  let hashedToken = hashString(res.locals.jwt, config.hmac_secret);
   let documentResponse = await getDocumentStrategy.getDocument(
     hashedToken,
-    this.config.dynamo_launch_context_table
+    config.dynamo_launch_context_table
   );
 
   if (documentResponse && documentResponse.launch) {

--- a/src/oauthHandlers/launchRequestHandler.js
+++ b/src/oauthHandlers/launchRequestHandler.js
@@ -20,7 +20,11 @@ const launchRequestHandler = async (
     hashString
   );
 
-  let documentResponse = await getDocumentStrategy.getDocument(res.locals.jwt);
+  let hashedToken = hashString(res.locals.jwt, this.config.hmac_secret);
+  let documentResponse = await getDocumentStrategy.getDocument(
+    hashedToken,
+    this.config.dynamo_launch_context_table
+  );
 
   if (documentResponse && documentResponse.launch) {
     res.json({ launch: documentResponse.launch });

--- a/src/oauthHandlers/tokenHandlerStrategyClasses/documentStrategies/getDocumentByAccessTokenStrategy.js
+++ b/src/oauthHandlers/tokenHandlerStrategyClasses/documentStrategies/getDocumentByAccessTokenStrategy.js
@@ -1,24 +1,20 @@
 const { rethrowIfRuntimeError } = require("../../../utils");
 
 class GetDocumentByAccessTokenStrategy {
-  constructor(logger, dynamoClient, config, hashingFunction) {
+  constructor(logger, dynamoClient, config) {
     this.logger = logger;
     this.dynamoClient = dynamoClient;
     this.config = config;
-    this.hashingFunction = hashingFunction;
   }
-  async getDocument(access_token) {
+  async getDocument(access_token, dynamo_table) {
     let document;
-    let hashedToken = this.hashingFunction(
-      access_token,
-      this.config.hmac_secret
-    );
+
     try {
       let payload = await this.dynamoClient.getPayloadFromDynamo(
         {
-          access_token: hashedToken,
+          access_token: access_token,
         },
-        this.config.dynamo_launch_context_table
+        dynamo_table
       );
       if (payload.Item) {
         document = payload.Item;

--- a/src/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClientBuilder.js
+++ b/src/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClientBuilder.js
@@ -73,6 +73,9 @@ const buildTokenHandlerClient = (
     strategies.tokenIssueCounter,
     strategies.dbMissCounter,
     logger,
+    config,
+    staticTokens,
+    dynamoClient,
     req,
     res,
     next
@@ -97,10 +100,7 @@ const getStrategies = (
       getTokenStrategy: new RefreshTokenStrategy(
         req,
         logger,
-        new issuer.Client(clientMetadata),
-        dynamoClient,
-        config,
-        staticTokens
+        new issuer.Client(clientMetadata)
       ),
       getDocumentFromDynamoStrategy: new GetDocumentByRefreshTokenStrategy(
         req,

--- a/src/oauthHandlers/tokenHandlerStrategyClasses/tokenStrategies/refreshTokenStrategy.js
+++ b/src/oauthHandlers/tokenHandlerStrategyClasses/tokenStrategies/refreshTokenStrategy.js
@@ -7,13 +7,10 @@ const {
 const { oktaTokenRefreshGauge, stopTimer } = require("../../../metrics");
 
 class RefreshTokenStrategy {
-  constructor(req, logger, client, dynamoClient, config, staticTokens) {
+  constructor(req, logger, client) {
     this.req = req;
     this.logger = logger;
     this.client = client;
-    this.dynamoClient = dynamoClient;
-    this.config = config;
-    this.staticTokens = staticTokens;
   }
 
   //will throw error if cannot retrieve refresh token
@@ -21,58 +18,19 @@ class RefreshTokenStrategy {
     let oktaTokenRefreshStart = process.hrtime.bigint();
     let tokens;
 
-    if (this.config.enable_static_token_service) {
-      try {
-        if (this.staticTokens.size == 0) {
-          let payload;
-          payload = await this.dynamoClient.scanFromDynamo(
-            this.config.dynamo_static_token_table
-          );
-          let self = this;
-          payload.Items.forEach(function (staticToken) {
-            self.staticTokens.set(staticToken.refresh_token, staticToken);
-          });
-        }
-      } catch (err) {
-        this.logger.error(
-          "Could not load static tokens list",
-          minimalError(err)
-        );
-      }
-      if (this.staticTokens.has(this.req.body.refresh_token)) {
-        let staticToken = this.staticTokens.get(this.req.body.refresh_token);
-        tokens = {
-          is_static: true,
-          access_token: staticToken.access_token,
-          refresh_token: staticToken.refresh_token,
-          token_type: "Bearer",
-          scope: staticToken.scopes,
-          expires_in: staticToken.expires_in,
-        };
-        if (staticToken.id_token) {
-          tokens.id_token = staticToken.id_token;
-        }
-        if (staticToken.icn) {
-          tokens.patient = staticToken.icn;
-        }
-        return tokens;
-      }
+    try {
+      tokens = await this.client.refresh(this.req.body.refresh_token);
+    } catch (error) {
+      rethrowIfRuntimeError(error);
+      let handledError = handleOpenIdClientError(error);
+      this.logger.error(
+        "Could not refresh the client session with the provided refresh token",
+        minimalError(handledError)
+      );
+      stopTimer(oktaTokenRefreshGauge, oktaTokenRefreshStart);
+      throw handledError;
     }
 
-    if (!tokens) {
-      try {
-        tokens = await this.client.refresh(this.req.body.refresh_token);
-      } catch (error) {
-        rethrowIfRuntimeError(error);
-        let handledError = handleOpenIdClientError(error);
-        this.logger.error(
-          "Could not refresh the client session with the provided refresh token",
-          minimalError(handledError)
-        );
-        stopTimer(oktaTokenRefreshGauge, oktaTokenRefreshStart);
-        throw handledError;
-      }
-    }
     stopTimer(oktaTokenRefreshGauge, oktaTokenRefreshStart);
     return tokens;
   }

--- a/src/oauthHandlers/tokenHandlerStrategyClasses/tokenStrategies/refreshTokenStrategy.js
+++ b/src/oauthHandlers/tokenHandlerStrategyClasses/tokenStrategies/refreshTokenStrategy.js
@@ -30,10 +30,7 @@ class RefreshTokenStrategy {
           );
           let self = this;
           payload.Items.forEach(function (staticToken) {
-            self.staticTokens.set(
-              staticToken.static_refresh_token,
-              staticToken
-            );
+            self.staticTokens.set(staticToken.refresh_token, staticToken);
           });
         }
       } catch (err) {
@@ -42,22 +39,21 @@ class RefreshTokenStrategy {
           minimalError(err)
         );
       }
-
       if (this.staticTokens.has(this.req.body.refresh_token)) {
         let staticToken = this.staticTokens.get(this.req.body.refresh_token);
         tokens = {
           is_static: true,
-          access_token: staticToken.static_access_token,
-          refresh_token: staticToken.static_refresh_token,
+          access_token: staticToken.access_token,
+          refresh_token: staticToken.refresh_token,
           token_type: "Bearer",
-          scope: staticToken.static_scopes,
-          expires_in: staticToken.static_expires_in,
+          scope: staticToken.scopes,
+          expires_in: staticToken.expires_in,
         };
-        if (staticToken.static_id_token) {
-          tokens.id_token = staticToken.static_id_token;
+        if (staticToken.id_token) {
+          tokens.id_token = staticToken.id_token;
         }
-        if (staticToken.static_icn) {
-          tokens.patient = staticToken.static_icn;
+        if (staticToken.icn) {
+          tokens.patient = staticToken.icn;
         }
         return tokens;
       }

--- a/tests/TokenHandlerTests/getDocumentByAccessTokenStrategy.test.js
+++ b/tests/TokenHandlerTests/getDocumentByAccessTokenStrategy.test.js
@@ -7,14 +7,12 @@ const {
   buildFakeDynamoClient,
   buildFakeLogger,
   createFakeConfig,
-  createFakeHashingFunction,
 } = require("../testUtils");
 
 describe("getDocument Tests", () => {
   let logger = buildFakeLogger();
   let dynamoClient;
   let config = createFakeConfig();
-  let hashingFunction = createFakeHashingFunction();
 
   it("Happy Path", async () => {
     dynamoClient = buildFakeDynamoClient({
@@ -25,9 +23,8 @@ describe("getDocument Tests", () => {
     let document = await new GetDocumentByAccessTokenStrategy(
       logger,
       dynamoClient,
-      config,
-      hashingFunction
-    ).getDocument("access_token");
+      config
+    ).getDocument("access_token", "launch_table");
 
     expect(document.access_token).toBe("access_token");
     expect(document.launch).toBe("launch");
@@ -42,9 +39,8 @@ describe("getDocument Tests", () => {
     let document = await new GetDocumentByAccessTokenStrategy(
       logger,
       dynamoClient,
-      config,
-      hashingFunction
-    ).getDocument("not_access_token");
+      config
+    ).getDocument("not_access_token", "launch_table");
 
     expect(document).toBe(undefined);
   });

--- a/tests/TokenHandlerTests/refreshTokenStrategy.test.js
+++ b/tests/TokenHandlerTests/refreshTokenStrategy.test.js
@@ -32,11 +32,7 @@ const realRefreshTests = async () => {
       },
     });
 
-    let refreshTokenStrategy = new RefreshTokenStrategy(
-      req,
-      logger,
-      client,
-    );
+    let refreshTokenStrategy = new RefreshTokenStrategy(req, logger, client);
 
     let token = await refreshTokenStrategy.getToken();
     expect(token.access_token).toEqual("real-access-token");
@@ -64,11 +60,7 @@ const realRefreshTests = async () => {
       },
     });
 
-    let refreshTokenStrategy = new RefreshTokenStrategy(
-      req,
-      logger,
-      client,
-    );
+    let refreshTokenStrategy = new RefreshTokenStrategy(req, logger, client);
 
     try {
       await refreshTokenStrategy.getToken();

--- a/tests/TokenHandlerTests/refreshTokenStrategy.test.js
+++ b/tests/TokenHandlerTests/refreshTokenStrategy.test.js
@@ -59,13 +59,13 @@ beforeEach(() => {
   });
   dynamoClient = jest.mock();
   setScan({
-    static_icn: "0123456789",
-    static_refresh_token: "static-refresh-token",
-    static_access_token: "static-access-token",
-    static_scopes:
+    icn: "0123456789",
+    refresh_token: "static-refresh-token",
+    access_token: "static-access-token",
+    scopes:
       "openid profile patient/Medication.read launch/patient offline_access",
-    static_expires_in: 3600,
-    static_id_token: "static-id-token",
+    expires_in: 3600,
+    id_token: "static-id-token",
   });
 });
 const realRefreshTests = async () => {
@@ -159,13 +159,13 @@ describe("tokenHandler refreshTokenStrategy", () => {
 
     it("happy path static token size > 0", async () => {
       staticTokens.set("static-refresh-token", {
-        static_icn: "0123456789",
-        static_refresh_token: "static-refresh-token",
-        static_access_token: "static-access-token",
-        static_scopes:
+        icn: "0123456789",
+        refresh_token: "static-refresh-token",
+        access_token: "static-access-token",
+        scopes:
           "openid profile patient/Medication.read launch/patient offline_access",
-        static_expires_in: 3600,
-        static_id_token: "static-id-token",
+        expires_in: 3600,
+        id_token: "static-id-token",
       });
       let req = new MockExpressRequest({
         body: {
@@ -191,12 +191,12 @@ describe("tokenHandler refreshTokenStrategy", () => {
     it("happy path no id icn", async () => {
       delete data.patient;
       setScan({
-        static_refresh_token: "static-refresh-token",
-        static_access_token: "static-access-token",
-        static_scopes:
+        refresh_token: "static-refresh-token",
+        access_token: "static-access-token",
+        scopes:
           "openid profile patient/Medication.read launch/patient offline_access",
-        static_expires_in: 3600,
-        static_id_token: "static-id-token",
+        expires_in: 3600,
+        id_token: "static-id-token",
       });
 
       let req = new MockExpressRequest({
@@ -222,12 +222,12 @@ describe("tokenHandler refreshTokenStrategy", () => {
     it("happy path no id token", async () => {
       delete data.id_token;
       setScan({
-        static_icn: "0123456789",
-        static_refresh_token: "static-refresh-token",
-        static_access_token: "static-access-token",
-        static_scopes:
+        icn: "0123456789",
+        refresh_token: "static-refresh-token",
+        access_token: "static-access-token",
+        scopes:
           "openid profile patient/Medication.read launch/patient offline_access",
-        static_expires_in: 3600,
+        expires_in: 3600,
       });
 
       let req = new MockExpressRequest({
@@ -255,11 +255,11 @@ describe("tokenHandler refreshTokenStrategy", () => {
       delete data.patient;
       delete data.id_token;
       setScan({
-        static_refresh_token: "static-refresh-token",
-        static_access_token: "static-access-token",
-        static_scopes:
+        refresh_token: "static-refresh-token",
+        access_token: "static-access-token",
+        scopes:
           "openid profile patient/Medication.read launch/patient offline_access",
-        static_expires_in: 3600,
+        expires_in: 3600,
       });
 
       let req = new MockExpressRequest({

--- a/tests/TokenHandlerTests/tokenHandlerClient.test.js
+++ b/tests/TokenHandlerTests/tokenHandlerClient.test.js
@@ -11,7 +11,6 @@ const {
   buildGetTokenStrategy,
 } = require("./tokenHandlerTestUtils");
 const { buildFakeDynamoClient, createFakeConfig } = require("../testUtils");
-const { encodeBasicAuthHeader } = require("../../src/utils");
 const MockExpressRequest = require("mock-express-request");
 const MockExpressResponse = require("mock-express-response");
 

--- a/tests/TokenHandlerTests/tokenHandlerClient.test.js
+++ b/tests/TokenHandlerTests/tokenHandlerClient.test.js
@@ -104,7 +104,7 @@ describe("handleToken tests", () => {
 
     req = Object.prototype.hasOwnProperty.call(clientConfig, "req")
       ? clientConfig.req
-      : new MockExpressRequest();
+      : new MockExpressRequest({ body: { grant_type: "authorization_code" } });
 
     res = Object.prototype.hasOwnProperty.call(clientConfig, "res")
       ? clientConfig.res
@@ -179,20 +179,10 @@ describe("handleToken tests", () => {
   });
 
   it("Happy Path no launch/patient", async () => {
-    let req = new MockExpressRequest({
-      body: {
-        grant_type: "authorization_code",
-      },
-    });
-    let config = {
-      enable_static_token_service: true,
-    };
     let token = buildToken(false, false, false, "email.read");
 
     let tokenHandlerClient = buildTokenClient({
       token: token,
-      req: req,
-      config: config,
       getTokenResponseStrategy: buildGetTokenStrategy(token),
       getPatientInfoStrategy: buildGetPatientInfoStrategy("patient"),
     });
@@ -205,19 +195,9 @@ describe("handleToken tests", () => {
   });
 
   it("Happy Path with launch/patient", async () => {
-    let req = new MockExpressRequest({
-      body: {
-        grant_type: "authorization_code",
-      },
-    });
-    let config = {
-      enable_static_token_service: false,
-    };
     let token = buildToken(false, true, true, "launch/patient");
 
     let tokenHandlerClient = buildTokenClient({
-      req: req,
-      config: config,
       token: token,
       getPatientInfoStrategy: buildGetPatientInfoStrategy("patient"),
     });
@@ -231,19 +211,9 @@ describe("handleToken tests", () => {
   });
 
   it("Happy Path with launch", async () => {
-    let req = new MockExpressRequest({
-      body: {
-        grant_type: "authorization_code",
-      },
-    });
-    let config = {
-      enable_static_token_service: false,
-    };
     let token = buildToken(false, true, false, "launch");
 
     let tokenHandlerClient = buildTokenClient({
-      req: req,
-      config: config,
       token: token,
       pullDocumentFromDynamoStrategy: buildGetDocumentStrategy({
         launch: "patient",
@@ -260,19 +230,9 @@ describe("handleToken tests", () => {
   });
 
   it("Happy Path with launch base64", async () => {
-    let req = new MockExpressRequest({
-      body: {
-        grant_type: "authorization_code",
-      },
-    });
-    let config = {
-      enable_static_token_service: false,
-    };
     let token = buildToken(false, true, false, "launch");
 
     let tokenHandlerClient = buildTokenClient({
-      req: req,
-      config: config,
       token: token,
       pullDocumentFromDynamoStrategy: buildGetDocumentStrategy({
         launch:
@@ -290,14 +250,6 @@ describe("handleToken tests", () => {
   });
 
   it("getToken 401 Response", async () => {
-    let req = new MockExpressRequest({
-      body: {
-        grant_type: "authorization_code",
-      },
-    });
-    let config = {
-      enable_static_token_service: false,
-    };
     let err = {
       statusCode: 401,
       error: "invalid_client",
@@ -305,8 +257,6 @@ describe("handleToken tests", () => {
     };
 
     let tokenHandlerClient = buildTokenClient({
-      req: req,
-      config: config,
       getTokenResponseStrategy: buildGetTokenStrategy(err, true),
     });
 
@@ -319,14 +269,6 @@ describe("handleToken tests", () => {
   });
 
   it("getToken 500 Response", async () => {
-    let req = new MockExpressRequest({
-      body: {
-        grant_type: "authorization_code",
-      },
-    });
-    let config = {
-      enable_static_token_service: false,
-    };
     let err = {
       statusCode: 500,
       error: "error",
@@ -334,8 +276,6 @@ describe("handleToken tests", () => {
     };
 
     let tokenHandlerClient = buildTokenClient({
-      req: req,
-      config: config,
       getTokenResponseStrategy: buildGetTokenStrategy(err, true),
     });
 
@@ -348,21 +288,11 @@ describe("handleToken tests", () => {
   });
 
   it("getToken non okta error", async () => {
-    let req = new MockExpressRequest({
-      body: {
-        grant_type: "authorization_code",
-      },
-    });
-    let config = {
-      enable_static_token_service: false,
-    };
     let err = {
       different: "this error does not follow the okta structure.",
     };
 
     let tokenHandlerClient = buildTokenClient({
-      req: req,
-      config: config,
       getTokenResponseStrategy: buildGetTokenStrategy(err, true),
     });
 
@@ -375,17 +305,7 @@ describe("handleToken tests", () => {
   });
 
   it("missing document returns 400 error (without metrics)", async () => {
-    let req = new MockExpressRequest({
-      body: {
-        grant_type: "authorization_code",
-      },
-    });
-    let config = {
-      enable_static_token_service: false,
-    };
     let tokenHandlerClient = buildTokenClient({
-      req: req,
-      config: config,
       pullDocumentFromDynamoStrategy: buildGetDocumentStrategy(undefined),
       dbMissCounter: undefined,
     });
@@ -398,17 +318,7 @@ describe("handleToken tests", () => {
   });
 
   it("missing document returns 400 error (with metrics)", async () => {
-    let req = new MockExpressRequest({
-      body: {
-        grant_type: "authorization_code",
-      },
-    });
-    let config = {
-      enable_static_token_service: false,
-    };
     let tokenHandlerClient = buildTokenClient({
-      req: req,
-      config: config,
       pullDocumentFromDynamoStrategy: buildGetDocumentStrategy(undefined),
       dbMissCounter: {
         inc: jest.fn(),

--- a/tests/bats/issued_tests.bats
+++ b/tests/bats/issued_tests.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+usage() {
+cat <<EOF
+Tests the Oauth Proxy's token endpoint.
+
+Example
+  HOST="https://sandbox-api.va.gov/oauth2" STATIC_ACCESS_TOKEN=$STATIC_ACCESS_TOKEN bats ./issued_tests.bats
+EOF
+}
+
+setup() {
+  if [ -z "$HOST" ]; then
+    echo "ERROR HOST is a required parameter."
+    usage
+    exit 0
+  fi
+
+  if [ -z "$STATIC_ACCESS_TOKEN" ]; then
+    echo "ERROR STATIC_ACCESS_TOKEN is a required parameter."
+    usage
+    exit 0
+  fi
+
+  curl_status="$(mktemp)"
+  curl_body="$(mktemp)"
+}
+
+teardown() {
+  rm $curl_status
+  rm $curl_body
+}
+
+do_issued() { 
+  local token=$1
+
+  curl -X GET \
+    -s \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    -H "Authorization: Bearer $token" \
+    -w "%{http_code}" \
+    -o "$curl_body" \
+    "$HOST/issued" > "$curl_status"
+}
+
+@test 'Valid static token' {
+  do_issued $STATIC_ACCESS_TOKEN
+  cat $curl_body
+  cat $curl_status
+  [ "$(cat "$curl_status")" -eq 200 ]
+  [ "$(cat "$curl_body" | jq .static | tr -d '"')" == "true" ]
+  [ "$(cat "$curl_body" | jq .scopes | tr -d '"')" == "openid profile patient/Medication.read launch/patient offline_access" ]
+  [ "$(cat "$curl_body" | jq .expires_in | tr -d '"')" == 3600 ]
+  [ "$(cat "$curl_body" | jq .icn | tr -d '"')" == "555" ]
+  [ "$(cat "$curl_body" | jq .aud | tr -d '"')" == "http://localhost:7100/services/static-only" ]
+}
+
+@test 'Invalid static token' {
+  do_issued bad
+  [ "$(cat "$curl_status")" -eq 401 ]
+  [ "$(cat "$curl_body")" == "Unauthorized" ]
+}

--- a/tests/bats/regression_tests.sh
+++ b/tests/bats/regression_tests.sh
@@ -172,7 +172,7 @@ CODE=$(assign_code)
 echo "Running Token Tests ..."
 token_file="$(mktemp)"
 expired_token_file="$(mktemp)"
-HOST="$HOST" CODE="$CODE" TOKEN_FILE="$token_file" EXPIRED_TOKEN_FILE="$expired_token_file" CLIENT_ID="$CLIENT_ID" CLIENT_SECRET="$CLIENT_SECRET" CC_CLIENT_ID="$CC_CLIENT_ID" CC_CLIENT_SECRET="$CC_CLIENT_SECRET" bats ./token_tests.bats
+HOST="$HOST" CODE="$CODE" TOKEN_FILE="$token_file" EXPIRED_TOKEN_FILE="$expired_token_file" CLIENT_ID="$CLIENT_ID" CLIENT_SECRET="$CLIENT_SECRET" CC_CLIENT_ID="$CC_CLIENT_ID" CC_CLIENT_SECRET="$CC_CLIENT_SECRET" STATIC_REFRESH_TOKEN="$STATIC_REFRESH_TOKEN" bats ./token_tests.bats
 status=$(($status + $?))
 # TOKEN and EXPIRED_ACCESS are assigned in token_tests.sh
 

--- a/tests/bats/regression_tests.sh
+++ b/tests/bats/regression_tests.sh
@@ -15,7 +15,7 @@ Example
   export CC_CLIENT_ID={{ client id }}
   export CC_CLIENT_SECRET={{ client secret }}
 
-  ./regression_tests.sh [--test-claims]
+  ./regression_tests.sh [--test-claims] [--test-issued]
 EOF
 exit 1
 }
@@ -25,6 +25,8 @@ do
 case $i in
     --test-claims)
       TEST_CLAIMS="true"; shift ;;
+    --test-issued)
+      TEST_ISSUED="true"; shift ;;
     --help|-h)
       usage ;  exit 1 ;;
     --) shift ; break ;;
@@ -85,6 +87,12 @@ fi
 if [ -z "$CC_CLIENT_SECRET" ];
 then
   echo "ERROR - CC_CLIENT_SECRET is a required parameter."
+  exit 1
+fi
+
+if [ "$TEST_ISSUED" == "true" ] && [ -z "$STATIC_ACCESS_TOKEN" ];
+then
+  echo "ERROR - STATIC_ACCESS_TOKEN is a required parameter."
   exit 1
 fi
 
@@ -179,6 +187,12 @@ status=$(($status + $?))
 if [ ! -z "$TEST_CLAIMS" ]; then
   echo "Running Claims Tests ..."
   HOST="$HOST" TOKEN_FILE="$token_file" bats "$DIR"/claims_tests.bats
+  status=$(($status + $?))
+fi
+
+if [ ! -z "$TEST_ISSUED" ]; then
+  echo "Running Issued Tests ..."
+  HOST="$HOST" STATIC_ACCESS_TOKEN="$STATIC_ACCESS_TOKEN" bats "$DIR"/issued_tests.bats
   status=$(($status + $?))
 fi
 

--- a/tests/bats/token_tests.bats
+++ b/tests/bats/token_tests.bats
@@ -139,6 +139,19 @@ do_token() {
     echo "$(cat "$curl_body")" > "$TOKEN_FILE"
   fi
 }
+
+do_static_token() {
+  payload="$1"
+  curl -X POST \
+    -s \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -w "%{http_code}" \
+    -o "$curl_body" \
+    -d "$payload" \
+    "$HOST/TOKEN?redirect_uri=$REDIRECT_URI" > "$curl_status"
+}
+
 @test 'Token Handler code happy path' {
   do_token "$(jq \
                 -scn \
@@ -334,7 +347,7 @@ do_token "$(jq \
     echo "STATIC_REFRESH_TOKEN is not provided for this test environment."
     skip
   fi
-  do_token "$(jq \
+  do_static_token "$(jq \
                 -scn \
                 --arg client_id "$CLIENT_ID" \
                 --arg grant_type "refresh_token" \
@@ -344,7 +357,6 @@ do_token "$(jq \
 
   [ "$(cat "$curl_status")" -eq 200 ]
   [ "$(cat "$curl_body" | jq 'has("access_token")')" == "true" ]
-  [ "$(cat "$curl_body" | jq 'has("id_token")')" == "true" ]
   [ "$(cat "$curl_body" | jq 'has("refresh_token")')" == "true" ]
   [ "$(cat "$curl_body" | jq .token_type | tr -d '"')" == "Bearer" ]
   [ "$(cat "$curl_body" | jq 'has("scope")')" == "true" ]

--- a/tests/dynamo_client.test.js
+++ b/tests/dynamo_client.test.js
@@ -92,12 +92,12 @@ describe("dynamo client tests", () => {
     let payloadDoc = {
       Items: [
         {
-          static_icn: "0123456789",
-          static_refresh_token: "ut_refresh_token",
-          static_access_token: "ut_access_token",
-          static_scopes:
+          icn: "0123456789",
+          refresh_token: "ut_refresh_token",
+          access_token: "ut_access_token",
+          scopes:
             "openid profile patient/Medication.read launch/patient offline_access",
-          static_expires_in: 3600,
+          expires_in: 3600,
         },
       ],
       Count: 1,
@@ -117,8 +117,8 @@ describe("dynamo client tests", () => {
     try {
       let result = await dynamoclient.scanFromDynamo("TestTable");
       expect(isCalled).toEqual(true);
-      expect(result.Items[0].static_access_token).toEqual("ut_access_token");
-      expect(result.Items[0].static_refresh_token).toEqual("ut_refresh_token");
+      expect(result.Items[0].access_token).toEqual("ut_access_token");
+      expect(result.Items[0].refresh_token).toEqual("ut_refresh_token");
     } catch (err) {
       // should not reach here
       fail("Should not reach here");

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -111,11 +111,11 @@ function buildMockDynamoClient(mockDynamoClientRecord) {
     const static_token = "123456789";
     const fakeStaticTokenRecord = {
       access_token: static_token,
-      static_scopes:
+      scopes:
         "openid profile patient/Medication.read launch/patient offline_access",
-      static_expires_in: 3600,
-      static_icn: "555",
-      static_aud: "http://localhost:7100/services/static-only",
+      expires_in: 3600,
+      icn: "555",
+      aud: "http://localhost:7100/services/static-only",
     };
     return new Promise((resolve, reject) => {
       let searchKey = Object.keys(search_params)[0];

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -116,6 +116,8 @@ function buildMockDynamoClient(mockDynamoClientRecord) {
       expires_in: 3600,
       icn: "555",
       aud: "http://localhost:7100/services/static-only",
+      cross_hash:
+        "c2f1a907ba44e76e140c334a1bc46e509e6e244cc2e9829a7e324d4791820d79",
     };
     return new Promise((resolve, reject) => {
       let searchKey = Object.keys(search_params)[0];

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -859,6 +859,34 @@ describe("OpenID Connect Conformance", () => {
       });
   });
 
+  it("missing authorization on a request for issued lookup", async () => {
+    await axios
+      .get("http://localhost:9090/testServer/issued")
+      .then(() => {
+        expect(true).toEqual(false); // Don't expect to be here
+      })
+      .catch((err) => {
+        expect(err.response.status).toEqual(401);
+        expect(err.response.statusText).toEqual("Unauthorized");
+      });
+  });
+
+  it("bad jwt on a request for issued lookup", async () => {
+    await axios
+      .get("http://localhost:9090/testServer/issued", {
+        headers: {
+          authorization: "Bearer invalid-static-token",
+        },
+      })
+      .then(() => {
+        expect(true).toEqual(false); // Don't expect to be here
+      })
+      .catch((err) => {
+        expect(err.response.status).toEqual(401);
+        expect(err.response.statusText).toEqual("Unauthorized");
+      });
+  });
+
   it("returns an OIDC conformant status 302 on valid authorization request", async () => {
     // By setting the maxRedirects to 0, the redirect uri can be checked without going through the whole flow
     await axios

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -105,34 +105,31 @@ function buildMockDynamoClient(mockDynamoClientRecord) {
     const hashed_smart_launch_token =
       "ab29a92e1db44913c896efeed12108faa0b47a944b56cd7cd07d121aefa3769a";
     const fakeLaunchRecord = {
+      access_token: hashed_smart_launch_token,
       launch: "123V456",
     };
     const static_token = "123456789";
     const fakeStaticTokenRecord = {
-      scopes:
+      access_token: static_token,
+      static_scopes:
         "openid profile patient/Medication.read launch/patient offline_access",
-      expires_in: 3600,
-      icn: "555",
-      aud: "http://localhost:7100/services/static-only",
+      static_expires_in: 3600,
+      static_icn: "555",
+      static_aud: "http://localhost:7100/services/static-only",
     };
     return new Promise((resolve, reject) => {
       let searchKey = Object.keys(search_params)[0];
-      console.log(searchKey);
-      console.log(tableName);
-      console.log(search_params);
       if (
         tableName === "launch_context_table" &&
         searchKey === "access_token" &&
         search_params[searchKey] === hashed_smart_launch_token
       ) {
-        mockDynamoClientRecord.access_token = hashed_smart_launch_token;
         resolve({ Item: fakeLaunchRecord });
       } else if (
         tableName === "StaticTokens" &&
         searchKey === "access_token" &&
         search_params[searchKey] === static_token
       ) {
-        mockDynamoClientRecord.access_token = hashed_smart_launch_token;
         resolve({ Item: fakeStaticTokenRecord });
       } else if (
         search_params[searchKey] === mockDynamoClientRecord[searchKey]
@@ -846,7 +843,7 @@ describe("OpenID Connect Conformance", () => {
       })
       .then((resp) => {
         expect(resp.status).toEqual(200);
-        expect(resp.data.static).toEqual("true");
+        expect(resp.data.static).toEqual(true);
         expect(resp.data.scopes).toEqual(
           "openid profile patient/Medication.read launch/patient offline_access"
         );

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -116,7 +116,7 @@ function buildMockDynamoClient(mockDynamoClientRecord) {
       expires_in: 3600,
       icn: "555",
       aud: "http://localhost:7100/services/static-only",
-      cross_hash:
+      check_sum:
         "c2f1a907ba44e76e140c334a1bc46e509e6e244cc2e9829a7e324d4791820d79",
     };
     return new Promise((resolve, reject) => {

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -116,7 +116,7 @@ function buildMockDynamoClient(mockDynamoClientRecord) {
       expires_in: 3600,
       icn: "555",
       aud: "http://localhost:7100/services/static-only",
-      check_sum:
+      checksum:
         "c2f1a907ba44e76e140c334a1bc46e509e6e244cc2e9829a7e324d4791820d79",
     };
     return new Promise((resolve, reject) => {

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -331,7 +331,7 @@ const createFakeConfig = () => {
     enable_okta_consent_endpoint: true,
     enable_smart_launch_service: true,
     enable_issued_service: true,
-    enable_static_token_service: true,
+    enable_static_token_service: false,
     dynamo_static_token_table: "ut_static_tokens_table",
     dynamo_clients_table: "Clients",
     routes: {

--- a/tests/testUtils.js
+++ b/tests/testUtils.js
@@ -330,6 +330,7 @@ const createFakeConfig = () => {
     enable_pkce_authorization_flow: true,
     enable_okta_consent_endpoint: true,
     enable_smart_launch_service: true,
+    enable_issued_service: true,
     enable_static_token_service: true,
     dynamo_static_token_table: "ut_static_tokens_table",
     dynamo_clients_table: "Clients",
@@ -389,6 +390,7 @@ const createFakeConfig = () => {
         jwks: "/keys",
         grants: "/grants",
         smart_launch: "/smart/launch",
+        issued: "/issued",
       },
     },
   };


### PR DESCRIPTION
## Related PRs

https://github.com/department-of-veterans-affairs/devops/pull/9772
https://github.com/department-of-veterans-affairs/terraform-aws-dvp-oauth-proxy/pull/25
https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy-configs/pull/41

## Test Commands

**for local testing**

```sh
export HOST=http://localhost:7100/oauth2
```

**Success**

```sh
curl -s -i -X GET \
  -H "Accept: application/json" \
  -H "Authorization: Bearer 123456789" \
  $HOST/issued 
```

- [x] status 200
- [x] expected response body

```json
{
  "static": true,
  "scopes": "openid profile patient/Medication.read launch/patient offline_access",
  "expires_in": 3600,
  "icn": "555",
  "aud": "http://localhost:7100/services/static-only"
}
```
**401**

```sh
curl -s -i -X GET \
  -H "Accept: application/json" \
  -H "Authorization: Bearer bad" \
  $HOST/issued 
```

- [x] status 401
- [x] expected response body
```
unauthorized
```

## New Regression Tests functionality

```
./regression_tests.sh
```

- [x] will not run issued tests

```
# STATIC_ACCESS_TOKEN not defined
./regression_tests.sh --test-issued
```

- [x] exit 1
- [x] echo `ERROR - STATIC_ACCESS_TOKEN is a required parameter.`

```
export STATIC_ACCESS_TOKEN=123456789
./regression_tests.sh --test-issued
```

```
Running Issued Tests ...
 ✓ Valid static token
 ✓ Invalid static token
```