### PR TITLE
API-9936 Persist audience on authorization

### DIFF
--- a/src/oauthHandlers/authorizeHandler.js
+++ b/src/oauthHandlers/authorizeHandler.js
@@ -75,6 +75,7 @@ const authorizeHandler = async (
       client_id: client_id,
       proxy:
         config.host + config.well_known_base_path + app_category.api_category,
+      aud: app_category.audience,
     };
 
     // If the launch scope is included then also

--- a/src/oauthHandlers/issuedRequestHandler.js
+++ b/src/oauthHandlers/issuedRequestHandler.js
@@ -141,6 +141,7 @@ const nonStaticTokenHandler = async (
       json: {
         static: false,
         proxy: nonStaticDocumentResponse.proxy,
+        aud: nonStaticDocumentResponse.aud,
       },
     };
   }

--- a/tests/bats/issued_tests.bats
+++ b/tests/bats/issued_tests.bats
@@ -70,6 +70,7 @@ do_issued() {
   [ "$(cat "$curl_status")" -eq 200 ]
   [ "$(cat "$curl_body" | jq .static | tr -d '"')" == "false" ]
   [ "$(cat "$curl_body" | jq 'has("proxy")')" == "true" ]
+  [ "$(cat "$curl_body" | jq 'has("aud")')" == "true" ]
 }
 
 @test 'General. Invalid token' {

--- a/tests/oauthHandlers/issued.test.js
+++ b/tests/oauthHandlers/issued.test.js
@@ -54,13 +54,18 @@ describe("Non Static Token Flow", () => {
           {
             access_token: dynamoQueryParams.access_token,
             proxy: "proxy",
+            aud: "aud",
           },
         ],
       }),
     };
 
     await issuedRequestHandler(config, logger, dynamoClient, req, res, next);
-    expect(res.json).toHaveBeenCalledWith({ static: false, proxy: "proxy" });
+    expect(res.json).toHaveBeenCalledWith({
+      static: false,
+      proxy: "proxy",
+      aud: "aud",
+    });
     expect(next).toHaveBeenCalledWith();
   });
 });


### PR DESCRIPTION
https://vajira.max.gov/browse/API-9936

To ensure only the specified audience(s) are valid for users of the token validation service, the OAuth proxy needs to store the audience at authorization to then return when the /issued endpoint is called.

These values are already maintained in the environment configurations on a per route basis, but may need to be added to your local configurations if they haven't been already.

Existing unit and integration tests have been updated to validate the `aud` value is present in the /issued response.