### PR TITLE
API-000 Allow issued endpoint without static token enabled

### DIFF
--- a/src/oauthHandlers/issuedRequestHandler.js
+++ b/src/oauthHandlers/issuedRequestHandler.js
@@ -37,7 +37,7 @@ const issuedRequestHandler = async (
     return res.sendStatus(401);
   }
 
-  let staticDocumentResponse
+  let staticDocumentResponse;
   if (config.enable_static_token_service) {
     staticDocumentResponse = await getDocumentStrategy.getDocument(
       access_token,

--- a/src/oauthHandlers/issuedRequestHandler.js
+++ b/src/oauthHandlers/issuedRequestHandler.js
@@ -36,10 +36,14 @@ const issuedRequestHandler = async (
   if (!access_token) {
     return res.sendStatus(401);
   }
-  let staticDocumentResponse = await getDocumentStrategy.getDocument(
-    access_token,
-    config.dynamo_static_token_table
-  );
+
+  let staticDocumentResponse
+  if (config.enable_static_token_service) {
+    staticDocumentResponse = await getDocumentStrategy.getDocument(
+      access_token,
+      config.dynamo_static_token_table
+    );
+  }
 
   let response =
     staticDocumentResponse && staticDocumentResponse.access_token

--- a/tests/oauthHandlers/issued.test.js
+++ b/tests/oauthHandlers/issued.test.js
@@ -76,6 +76,7 @@ describe("Static Token Flow", () => {
   beforeEach(() => {
     req = { headers: { authorization: `Bearer ${token}` } };
     dynamoClient = {};
+    config.enable_static_token_service = true;
   });
 
   it("Checksum does not match", async () => {
@@ -120,6 +121,23 @@ describe("Static Token Flow", () => {
       aud: "aud",
     });
     expect(next).toHaveBeenCalledWith();
+  });
+
+  it("Static token but not enabled", async () => {
+    config.enable_static_token_service = false;
+    dynamoClient = {
+      getPayloadFromDynamo: jest.fn().mockReturnValue([]),
+      queryFromDynamo: jest.fn().mockReturnValue({
+        Items: [
+          {
+            access_token: dynamoQueryParams.access_token,
+          },
+        ],
+      }),
+    };
+
+    await issuedRequestHandler(config, logger, dynamoClient, req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
   });
 });
 


### PR DESCRIPTION
Small change to ensure that `config.enable_static_token_service` is checked for the /issued endpoint similar to the /token endpoint.

This will allow promotion of the issued service without being blocked by any static token testing in lower environments.