### PR TITLE
API-10571 Enable CORS for token request

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -345,7 +345,7 @@ function buildApp(
     );
 
     router.options(api_category + app_routes.token, corsHandler);
-cors
+
     if (app_category.manage_endpoint) {
       router.get(api_category + app_routes.manage, (req, res) =>
         res.redirect(app_category.manage_endpoint)

--- a/src/index.js
+++ b/src/index.js
@@ -322,24 +322,30 @@ function buildApp(
     });
 
     const staticTokens = new Map();
-    router.post(api_category + app_routes.token, async (req, res, next) => {
-      await oauthHandlers
-        .tokenHandler(
-          config,
-          redirect_uri,
-          logger,
-          service_issuer,
-          dynamoClient,
-          validateToken,
-          staticTokens,
-          app_category,
-          req,
-          res,
-          next
-        )
-        .catch(next);
-    });
+    router.post(
+      api_category + app_routes.token,
+      corsHandler,
+      async (req, res, next) => {
+        await oauthHandlers
+          .tokenHandler(
+            config,
+            redirect_uri,
+            logger,
+            service_issuer,
+            dynamoClient,
+            validateToken,
+            staticTokens,
+            app_category,
+            req,
+            res,
+            next
+          )
+          .catch(next);
+      }
+    );
 
+    router.options(api_category + app_routes.token, corsHandler);
+cors
     if (app_category.manage_endpoint) {
       router.get(api_category + app_routes.manage, (req, res) =>
         res.redirect(app_category.manage_endpoint)

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -262,6 +262,27 @@ describe("OpenID Connect Conformance", () => {
     );
   });
 
+  it("allows CORS on the OIDC token endpoint", async () => {
+    const randomHeaderName = randomBytes(20).toString("hex");
+    const options = {
+      headers: {
+        origin: "http://localhost:8080",
+        "access-control-request-headers": randomHeaderName,
+      },
+    };
+    const resp = await axios.options(
+      "http://localhost:9090/testServer/token",
+      options
+    );
+    expect(resp.status).toEqual(200);
+    expect(resp.headers["access-control-allow-headers"]).toMatch(
+      randomHeaderName
+    );
+    expect(resp.headers["access-control-allow-origin"]).toMatch(
+      FAKE_CLIENT_APP_URL_PATTERN
+    );
+  });
+
   it("responds to the endpoints described in the OIDC metadata response", async () => {
     // This test is making multiple requests. Theoretically it could be broken
     // up, with each request being made in a separate test. That would make it


### PR DESCRIPTION
https://vajira.max.gov/browse/API-10571

Following the spike to evaluate the impact of enabling cross-origin resource sharing, this PR enables CORS for the /token endpoint.  This allows single page applications (SPAs) to obtain access tokens to use Lighthouse OAuth API's with the Authorization Code flow + PKCE.

OPTIONS handling was added to the /token endpoint as well as the `corsHandler` passed to the /token route itself.