### PR TITLE
API-13145 Upgrade okta-sdk-nodejs to 6.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "CC0-1.0",
       "dependencies": {
-        "@okta/okta-sdk-nodejs": "^6.0.0",
+        "@okta/okta-sdk-nodejs": "^6.3.0",
         "@sentry/node": "^6.2.3",
         "aws-sdk": "^2.859.0",
         "axios": "^0.21.2",
@@ -1371,9 +1371,9 @@
       }
     },
     "node_modules/@okta/okta-sdk-nodejs": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@okta/okta-sdk-nodejs/-/okta-sdk-nodejs-6.1.0.tgz",
-      "integrity": "sha512-cG7Jah/hpfUqAYRl89m8WOE40k/T+WgFw6bnPSO/adqGpfdbBnqEZ90pGQNkixdSOV/j2EnZJxyGADxpR8b/Iw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@okta/okta-sdk-nodejs/-/okta-sdk-nodejs-6.3.0.tgz",
+      "integrity": "sha512-ll8y1uc0/oBVOyuYZItRo70ZcMUZsfqoqRlBFxwkGvcJRLSB0IFZO0R4Z76ZVG/TF++zj5sLnZrnWya6MKA1dA==",
       "dependencies": {
         "deep-copy": "^1.4.2",
         "form-data": "^4.0.0",
@@ -1381,7 +1381,7 @@
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.20",
         "njwt": "^1.0.0",
-        "parse-link-header": "^1.0.1",
+        "parse-link-header": "^2.0.0",
         "rasha": "^1.2.5",
         "safe-flat": "^2.0.2"
       },
@@ -7150,9 +7150,9 @@
       }
     },
     "node_modules/parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
       "dependencies": {
         "xtend": "~4.0.1"
       }
@@ -9769,9 +9769,9 @@
       }
     },
     "@okta/okta-sdk-nodejs": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@okta/okta-sdk-nodejs/-/okta-sdk-nodejs-6.1.0.tgz",
-      "integrity": "sha512-cG7Jah/hpfUqAYRl89m8WOE40k/T+WgFw6bnPSO/adqGpfdbBnqEZ90pGQNkixdSOV/j2EnZJxyGADxpR8b/Iw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@okta/okta-sdk-nodejs/-/okta-sdk-nodejs-6.3.0.tgz",
+      "integrity": "sha512-ll8y1uc0/oBVOyuYZItRo70ZcMUZsfqoqRlBFxwkGvcJRLSB0IFZO0R4Z76ZVG/TF++zj5sLnZrnWya6MKA1dA==",
       "requires": {
         "deep-copy": "^1.4.2",
         "form-data": "^4.0.0",
@@ -9779,7 +9779,7 @@
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.20",
         "njwt": "^1.0.0",
-        "parse-link-header": "^1.0.1",
+        "parse-link-header": "^2.0.0",
         "rasha": "^1.2.5",
         "safe-flat": "^2.0.2"
       }
@@ -14151,9 +14151,9 @@
       }
     },
     "parse-link-header": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
-      "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",
+      "integrity": "sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==",
       "requires": {
         "xtend": "~4.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "homepage": "https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy#readme",
   "dependencies": {
-    "@okta/okta-sdk-nodejs": "^6.0.0",
+    "@okta/okta-sdk-nodejs": "^6.3.0",
     "@sentry/node": "^6.2.3",
     "aws-sdk": "^2.859.0",
     "axios": "^0.21.2",


### PR DESCRIPTION
Update to address vulnerability.

```
Dependabot cannot update parse-link-header to a non-vulnerable version
The latest possible version that can be installed is 1.0.1 because of the following conflicting dependency:

@okta/okta-sdk-nodejs@6.1.0 requires parse-link-header@^1.0.1
The earliest fixed version is 2.0.0.
```