### PR TITLE
API-000 Fix deploy pipeline

### DIFF
--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -57,7 +57,7 @@ phases:
     commands:
       # There is considerable slow down in the provisioning phase when using Amazon provided images.
       # Therefore we use our own Alpine based image. In order to activate the Docker Daemon these lines are needed.
-      - /usr/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &
+      - /usr/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 &
       - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
   pre_build:
     commands:


### PR DESCRIPTION
Fix for CI
https://github.com/department-of-veterans-affairs/lighthouse-devops-support/issues/1174

...
level=error msg="failed to mount overlay: invalid argument" storage-driver=overlay2
...
failed to start daemon: error initializing graphdriver: driver not supported
...

Follow up to the build portion
https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy/pull/55