### PR TITLE
API-13878 apigee oauth proxy

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -123,7 +123,8 @@ function processArgs() {
       },
       redirects_header: {
         type: "string",
-        description: "The the header used to determine the condition for a rewrite of the redirect url",
+        description:
+          "The the header used to determine the condition for a rewrite of the redirect url",
         required: false,
         default: "x-lighthouse-gateway",
       },
@@ -134,12 +135,11 @@ function processArgs() {
         required: false,
         condition: {
           description:
-          "A string used to match the value in the request header for determine the correct redirect url",
+            "A string used to match the value in the request header for determine the correct redirect url",
           required: true,
         },
         uri: {
-          description:
-          "A string that represents the redirect url",
+          description: "A string that represents the redirect url",
           required: true,
         },
       },

--- a/src/cli.js
+++ b/src/cli.js
@@ -121,6 +121,28 @@ function processArgs() {
         required: false,
         default: false,
       },
+      redirects_header: {
+        type: "string",
+        description: "The the header used to determine the condition for a rewrite of the redirect url",
+        required: false,
+        default: "x-lighthouse-gateway",
+      },
+      redirects: {
+        type: "array",
+        description:
+          "An array of objects that enables redirect_url rewrites based on the value of a request header",
+        required: false,
+        condition: {
+          description:
+          "A string used to match the value in the request header for determine the correct redirect url",
+          required: true,
+        },
+        uri: {
+          description:
+          "A string that represents the redirect url",
+          required: true,
+        },
+      },
       routes: {
         description:
           "An object that describes route configurations for isolated api categories",

--- a/src/cli.js
+++ b/src/cli.js
@@ -124,7 +124,7 @@ function processArgs() {
       redirects_header: {
         type: "string",
         description:
-          "The the header used to determine the condition for a rewrite of the redirect url",
+          "The header used to determine the condition for a rewrite of the redirect url",
         required: false,
         default: "x-lighthouse-gateway",
       },

--- a/src/oauthHandlers/authorizeHandler.js
+++ b/src/oauthHandlers/authorizeHandler.js
@@ -2,7 +2,7 @@ const { URLSearchParams, URL } = require("url");
 const { loginBegin } = require("../metrics");
 const { v4: uuidv4 } = require("uuid");
 const { addMinutes, getUnixTime } = require("date-fns");
-const { screenClientForFallback } = require("../utils");
+const { screenClientForFallback, rewriteRedirect } = require("../utils");
 /**
  * Checks for valid authorization request and proxies to authorization server.
  *
@@ -115,7 +115,7 @@ const authorizeHandler = async (
 
   const params = new URLSearchParams(req.query);
   params.set("client_id", client_id);
-  params.set("redirect_uri", redirect_uri);
+  params.set("redirect_uri", rewriteRedirect(config, req, redirect_uri));
   // Rewrite to an internally maintained state
   params.set("state", internal_state);
 

--- a/src/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClientBuilder.js
+++ b/src/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClientBuilder.js
@@ -76,7 +76,7 @@ const buildTokenHandlerClient = async (
   app_category
 ) => {
   const strategies = await getStrategies(
-    rewriteRedirect(redirect_uri),
+    rewriteRedirect(config, req, redirect_uri),
     issuer,
     logger,
     dynamoClient,

--- a/src/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClientBuilder.js
+++ b/src/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClientBuilder.js
@@ -32,7 +32,11 @@ const {
 const {
   GetPatientInfoFromLaunchStrategy,
 } = require("./getPatientInfoStrategies/getPatientInfoFromLaunchStrategy");
-const { parseBasicAuth, screenClientForFallback } = require("../../utils");
+const {
+  parseBasicAuth,
+  screenClientForFallback,
+  rewriteRedirect,
+} = require("../../utils");
 const {
   codeTokenIssueCounter,
   refreshTokenIssueCounter,
@@ -72,7 +76,7 @@ const buildTokenHandlerClient = async (
   app_category
 ) => {
   const strategies = await getStrategies(
-    redirect_uri,
+    rewriteRedirect(redirect_uri),
     issuer,
     logger,
     dynamoClient,

--- a/src/utils.js
+++ b/src/utils.js
@@ -275,6 +275,16 @@ const getProxyRequest = async (
   return proxy_request;
 };
 
+const rewriteRedirect = (config, request) => {
+  if (config.redirects) {
+    const redirect = config.redirects
+      .find((r) => r.condition === request.header["X-Lighthouse-Gateway"])
+      .orElse((r) => r.condition === "default");
+    request.query.redirect_uri = redirect;
+  }
+  return request;
+};
+
 module.exports = {
   isRuntimeError,
   rethrowIfRuntimeError,
@@ -289,4 +299,5 @@ module.exports = {
   screenClientForFallback,
   appCategoryFromPath,
   getProxyRequest,
+  rewriteRedirect,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -277,10 +277,10 @@ const getProxyRequest = async (
 
 const rewriteRedirect = (config, request, redirect_uri) => {
   if (config.redirects && request.header["X-Lighthouse-Gateway"]) {
-    const redirect = config.redirects
+    const redirectUrl = config.redirects
       .find((r) => r.condition === request.header["X-Lighthouse-Gateway"])
       .orElse((r) => r.condition === "default");
-    return redirect;
+    return redirectUrl;
   }
   return redirect_uri;
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -276,9 +276,9 @@ const getProxyRequest = async (
 };
 
 const rewriteRedirect = (config, request, redirect_uri) => {
-  if (config.redirects && request.header["X-Lighthouse-Gateway"]) {
+  if (config.redirects && request.headers["X-Lighthouse-Gateway"]) {
     const redirectUrl = config.redirects
-      .find((r) => r.condition === request.header["X-Lighthouse-Gateway"])
+      .find((r) => r.condition === request.headers["X-Lighthouse-Gateway"])
       .orElse((r) => r.condition === "default");
     return redirectUrl;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -276,7 +276,7 @@ const getProxyRequest = async (
 };
 
 const rewriteRedirect = (config, request, redirect_uri) => {
-  if (config.redirects) {
+  if (config.redirects && request.header["X-Lighthouse-Gateway"]) {
     const redirect = config.redirects
       .find((r) => r.condition === request.header["X-Lighthouse-Gateway"])
       .orElse((r) => r.condition === "default");

--- a/src/utils.js
+++ b/src/utils.js
@@ -284,7 +284,7 @@ const rewriteRedirect = (config, request, redirect_uri) => {
     redirectUrl = redirectUrl
       ? redirectUrl
       : config.redirects.find((r) => r.condition === "default");
-    return redirectUrl ? redirectUrl : redirect_uri;
+    return redirectUrl ? redirectUrl.uri : redirect_uri;
   }
   return redirect_uri;
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -283,8 +283,8 @@ const getProxyRequest = async (
  * @returns The potentially rewritten url.
  */
 const rewriteRedirect = (config, request, redirect_uri) => {
-  if (config.redirects && request.headers["x-lighthouse-gateway"]) {
-    const xLighthouseGateway = request.headers["x-lighthouse-gateway"];
+  if (config.redirects && request.headers[config.redirects_header]) {
+    const xLighthouseGateway = request.headers[config.redirects_header];
     let redirectUrl = config.redirects.find(
       (r) => r.condition === xLighthouseGateway
     );

--- a/src/utils.js
+++ b/src/utils.js
@@ -275,6 +275,13 @@ const getProxyRequest = async (
   return proxy_request;
 };
 
+/**
+ * Determines the value of the redirect url based on a request header setting.
+ * @param {*} config application configuration.
+ * @param {express.Request} request express request object.
+ * @param {*} redirect_uri the orignal redirect url
+ * @returns The potentially rewritten url.
+ */
 const rewriteRedirect = (config, request, redirect_uri) => {
   if (config.redirects && request.headers["x-lighthouse-gateway"]) {
     const xLighthouseGateway = request.headers["x-lighthouse-gateway"];

--- a/src/utils.js
+++ b/src/utils.js
@@ -275,14 +275,14 @@ const getProxyRequest = async (
   return proxy_request;
 };
 
-const rewriteRedirect = (config, request) => {
+const rewriteRedirect = (config, request, redirect_uri) => {
   if (config.redirects) {
     const redirect = config.redirects
       .find((r) => r.condition === request.header["X-Lighthouse-Gateway"])
       .orElse((r) => r.condition === "default");
-    request.query.redirect_uri = redirect;
+    return redirect;
   }
-  return request;
+  return redirect_uri;
 };
 
 module.exports = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -276,11 +276,15 @@ const getProxyRequest = async (
 };
 
 const rewriteRedirect = (config, request, redirect_uri) => {
-  if (config.redirects && request.headers["X-Lighthouse-Gateway"]) {
-    const redirectUrl = config.redirects
-      .find((r) => r.condition === request.headers["X-Lighthouse-Gateway"])
-      .orElse((r) => r.condition === "default");
-    return redirectUrl;
+  if (config.redirects && request.headers["x-lighthouse-gateway"]) {
+    const xLighthouseGateway = request.headers["x-lighthouse-gateway"];
+    let redirectUrl = config.redirects.find(
+      (r) => r.condition === xLighthouseGateway
+    );
+    redirectUrl = redirectUrl
+      ? redirectUrl
+      : config.redirects.find((r) => r.condition === "default");
+    return redirectUrl ? redirectUrl : redirect_uri;
   }
   return redirect_uri;
 };

--- a/tests/bats/regression_tests.sh
+++ b/tests/bats/regression_tests.sh
@@ -131,9 +131,9 @@ track_result() {
 
 assign_code() {
   local network=""
-  if [[ $HOST == *"lighthouse-oauth-proxy-oauth-proxy-1"* ]];
+  if [[ $HOST == *"localhost"* ]];
   then
-    network="-i --network lighthouse-oauth-proxy_default"
+    network="-i --network container:lighthouse-oauth-proxy_oauth-proxy_1"
   else
     network=""
   fi

--- a/tests/bats/regression_tests.sh
+++ b/tests/bats/regression_tests.sh
@@ -131,9 +131,9 @@ track_result() {
 
 assign_code() {
   local network=""
-  if [[ $HOST == *"localhost"* ]];
+  if [[ $HOST == *"lighthouse-oauth-proxy-oauth-proxy-1"* ]];
   then
-    network="-i --network container:lighthouse-oauth-proxy_oauth-proxy_1"
+    network="-i --network lighthouse-oauth-proxy_default"
   else
     network=""
   fi

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -453,6 +453,7 @@ describe("getProxyRequest tests", () => {
 
 describe("rewriteRedirect tests", () => {
   beforeEach(() => {
+    config.redirects_header = "x-lighthouse-gateway";
     config.redirects = [
       {
         condition: "api2",

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -501,7 +501,11 @@ describe("rewriteRedirect tests", () => {
         host: "localhost",
       },
     };
-    const result = rewriteRedirect(config, req, "http://original/oauth2/redirect");
+    const result = rewriteRedirect(
+      config,
+      req,
+      "http://original/oauth2/redirect"
+    );
     expect(result).toBe("http://original/oauth2/redirect");
   });
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -14,6 +14,7 @@ const {
   screenClientForFallback,
   appCategoryFromPath,
   getProxyRequest,
+  rewriteRedirect,
 } = require("../src/utils");
 
 describe("statusCodeFromError", () => {
@@ -447,5 +448,31 @@ describe("getProxyRequest tests", () => {
     );
     expect(result.data).toBe("client_id=testClient2");
     expect(result.url).toBe("http://fallback.com/introspect");
+  });
+});
+
+describe("rewriteRedirect tests", () => {
+  beforeEach(() => {
+    config.redirects = [
+      {
+        condition: "api2",
+        uri: "http://api2/oauth2/redirect",
+      },
+      {
+        condition: "default",
+        uri: "http://default/oauth2/redirect",
+      },
+    ];
+  });
+
+  it("rewriteRedirect default", async () => {
+    const req = {
+      headers: {
+        host: "localhost",
+        "x-lighthouse-gateway": "default",
+      },
+    };
+    const result = rewriteRedirect(config, req, "http:/not_this_redirect");
+    expect(result).toBe("http://default/oauth2/redirect");
   });
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -464,7 +464,6 @@ describe("rewriteRedirect tests", () => {
       },
     ];
   });
-
   it("rewriteRedirect default", async () => {
     const req = {
       headers: {
@@ -474,5 +473,24 @@ describe("rewriteRedirect tests", () => {
     };
     const result = rewriteRedirect(config, req, "http:/not_this_redirect");
     expect(result).toBe("http://default/oauth2/redirect");
+  });
+  it("rewriteRedirect api2", async () => {
+    const req = {
+      headers: {
+        host: "localhost",
+        "x-lighthouse-gateway": "api2",
+      },
+    };
+    const result = rewriteRedirect(config, req, "http:/not_this_redirect");
+    expect(result).toBe("http://api2/oauth2/redirect");
+  });
+  it("rewriteRedirect original", async () => {
+    const req = {
+      headers: {
+        host: "localhost",
+      },
+    };
+    const result = rewriteRedirect(config, req, "http://original/oauth2/redirect");
+    expect(result).toBe("http://original/oauth2/redirect");
   });
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -464,6 +464,17 @@ describe("rewriteRedirect tests", () => {
       },
     ];
   });
+  it("rewriteRedirect old_config", async () => {
+    config.redirects = undefined;
+    const req = {
+      headers: {
+        host: "localhost",
+        "x-lighthouse-gateway": "default",
+      },
+    };
+    const result = rewriteRedirect(config, req, "http://orig/oauth2/redirect");
+    expect(result).toBe("http://orig/oauth2/redirect");
+  });
   it("rewriteRedirect default", async () => {
     const req = {
       headers: {


### PR DESCRIPTION
Addresses API-13878
 - enables config-driven setting of redirect URL using a flag passed, via a header from the originating request.
 - this will enable to use of apigee as the gateway for the api's

The dev-config.json will need the following configuration items added.

```
  "redirects_header": "x-lighthouse-gateway",
  "redirects": [
    {
      "condition": "apigee",
      "uri": "http://localhost:12345/oauth2/redirect"
    },
    {
      "condition": "default",
      "uri": "http://localhost:7100/oauth2/redirect"
    }
  ],  
```

To test the behavior a gateway has to be mimic'ed. To do this use nginx as follows.

Store the following text in a file at /path/to/nginx/default.conf

```
server {
    listen       80;
    listen  [::]:80;
    server_name  localhost;
    
    #access_log  /var/log/nginx/host.access.log  main;

    location / {
        root   /usr/share/nginx/html;
        index  index.html index.htm;
    }

    location /oauth2 {
        proxy_pass   http://host.docker.internal:7100;
        proxy_set_header x-lighthouse-gateway "apigee";
        proxy_pass_request_headers on;
    }

    #error_page  404              /404.html;

    # redirect server error pages to the static page /50x.html
    #
    error_page   500 502 503 504  /50x.html;
    location = /50x.html {
        root   /usr/share/nginx/html;
    }
 
}


```

Next start nginx as follows

```
docker run --name simulated-gateway-container -v /path/to/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro -p 12345:80 -d nginx
```

When testing use

```
 AUTHORIZATION_URL=http://localhost:12345/oauth2
```

or

```
 HOST=http://localhost:12345/oauth2
```

for running the regression tests

To test the default path

```
docker stop simulated-gateway-container
````

alter "/path/to/nginx/default.conf" with

```
    location /oauth2 {
        proxy_pass   http://host.docker.internal:7100;
        proxy_set_header x-lighthouse-gateway "default";
        proxy_pass_request_headers on;
    }
```

then

```
docker start simulated-gateway-container
````

