### PR TITLE
API-13878 no docker regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ tests/coverage
 
 ## Webstorm
 .idea/
+
+# For node-based regression testing
+tests/bats/package-lock.json

--- a/tests/bats/package.json
+++ b/tests/bats/package.json
@@ -2,10 +2,6 @@
   "name": "oauth_proxy_regression_tests",
   "version": "1.0.0",
   "description": "Oauth Proxy regression tests.",
-  "main": "oauth-proxy-regression.test.js",
-  "scripts": {
-    "test": "jest -- oauth-proxy-regression.test.js"
-  },
   "keywords": [
     "oauth-proxy-bats-tests"
   ],

--- a/tests/bats/package.json
+++ b/tests/bats/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "oauth_proxy_regression_tests",
+  "version": "1.0.0",
+  "description": "Oauth Proxy regression tests.",
+  "main": "oauth-proxy-regression.test.js",
+  "scripts": {
+    "test": "jest -- oauth-proxy-regression.test.js"
+  },
+  "keywords": [
+    "oauth-proxy-bats-tests"
+  ],
+  "author": "Pivot!",
+  "license": "ISC",
+  "dependencies": {
+    "lighthouse-auth-utils": "git+https://github.com/department-of-veterans-affairs/lighthouse-auth-utils.git"
+  }
+}

--- a/tests/bats/token_tests.bats
+++ b/tests/bats/token_tests.bats
@@ -113,9 +113,13 @@ do_client_credentials() {
     network="-i --network container:lighthouse-oauth-proxy_oauth-proxy_1"
   fi
 
+  local auth_cmd="docker run $network --rm vasdvp/lighthouse-auth-utils:latest auth-cc.js"
+  if [ $NO_DOCKER ]; then
+     auth_cmd="node node_modules/lighthouse-auth-utils/auth-cc.js"
+  fi
+
   local cc
-  cc="$(docker run $network --rm \
-          vasdvp/lighthouse-auth-utils:latest auth-cc \
+  cc="$($auth_cmd \
           --client-id="$CC_CLIENT_ID" \
           --client-secret="$CC_CLIENT_SECRET" \
           --authorization-url=$url \

--- a/tests/bats/token_tests.bats
+++ b/tests/bats/token_tests.bats
@@ -113,7 +113,7 @@ do_client_credentials() {
     network="-i --network container:lighthouse-oauth-proxy_oauth-proxy_1"
   fi
 
-  local auth_cmd="docker run $network --rm vasdvp/lighthouse-auth-utils:latest auth-cc.js"
+  local auth_cmd="docker run $network --rm vasdvp/lighthouse-auth-utils:latest auth-cc"
   if [ $NO_DOCKER ]; then
      auth_cmd="node node_modules/lighthouse-auth-utils/auth-cc.js"
   fi


### PR DESCRIPTION
Used to support https://vajira.max.gov/browse/API-13878
 - Enables regression testing without the use of docker
   - On a locked-down MacOS machine, puppeteer was not able to run from within a docker container
   - This was due to a machine policy and didn't allow an embedded chromium to run without a user allowing it on a pop-up dialog
 - If the `NO_DOCKER` environment variable is not set, then the original docker-based regression testing is still used

To run regression testing without docker 

```
export NO_DOCKER=true
cd tests/bats
./regression_tests.sh
```
